### PR TITLE
Allow Wallet to define the validity of WUA during issuance requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,10 +415,14 @@ Default value: N/A
 
 ### Wallet Unit Attestation Configuration
 
-Variable: `WALLETAUNITATTESTATION_VALIDITY`  
-Description: Duration a Wallet Unit Attestations is valid for.    
+Variable: `WALLETAUNITATTESTATION_VALIDITY_MINIMUM`  
+Description: Minimum duration a Wallet Unit Attestations is valid for.    
 Default value: `31 days`  
 Minimum value: `31 days`  
+
+Variable: `WALLETAUNITATTESTATION_VALIDITY_MAXIMUM`  
+Description: Maximum duration a Wallet Unit Attestations is valid for.    
+Default value: `62 days`  
 
 Variable: `WALLETUNITATTESTATION_KEYSTORAGE_XX`  
 Description: Case sensitive strings that assert the attack potential resistance of the key storage component and its keys attested.  

--- a/README.md
+++ b/README.md
@@ -403,8 +403,7 @@ Default value: N/A
 
 Variable: `WALLETINSTANCEATTESTATION_VALIDITY`  
 Description: Duration a Wallet Instance Attestations is valid for.  
-Default value: `24 hours`  
-Maximum value: `24 hours`  
+Default value: `5 minutes`  
 
 Variable: `WALLETINSTANCEATTESTATION_WALLETNAME`  
 Description: Wallet Name that will be included in the Wallet Instance Attestations.  

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -349,9 +349,10 @@
           "H1"
         ]
       },
-      "Duration": {
-        "type": "string",
-        "description": "ISO 8601 duration format, e.g. PT1H for 1 hour"
+      "SecondsDuration": {
+        "type": "number",
+        "format": "int64",
+        "description": "Duration in seconds"
       },
       "AndroidPlatformKeyAttestationWalletInstanceAttestationIssuanceRequest": {
         "type": "object",
@@ -500,8 +501,8 @@
             },
             "minItems": 1
           },
-          "validity": {
-            "$ref": "#/components/schemas/Duration"
+          "preferred_ttl": {
+            "$ref": "#/components/schemas/SecondsDuration"
           }
         },
         "required": [
@@ -526,7 +527,7 @@
         "type": "string",
         "enum": [
           "unsupported_signing_algorithms",
-          "minimum_validity_not_exceeded",
+          "invalid_preferred_ttl",
           "invalid_challenge",
           "invalid_key_attestation",
           "unsupported_attested_key",
@@ -576,8 +577,8 @@
             },
             "minItems": 1
           },
-          "validity": {
-            "$ref": "#/components/schemas/Duration"
+          "preferred_ttl": {
+            "$ref": "#/components/schemas/SecondsDuration"
           }
         },
         "required": [
@@ -619,8 +620,8 @@
             },
             "minItems": 1
           },
-          "validity": {
-            "$ref": "#/components/schemas/Duration"
+          "preferred_ttl": {
+            "$ref": "#/components/schemas/SecondsDuration"
           }
         },
         "required": [

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -349,6 +349,10 @@
           "H1"
         ]
       },
+      "Duration": {
+        "type": "string",
+        "description": "ISO 8601 duration format, e.g. PT1H for 1 hour"
+      },
       "AndroidPlatformKeyAttestationWalletInstanceAttestationIssuanceRequest": {
         "type": "object",
         "properties": {
@@ -364,6 +368,9 @@
               "$ref": "#/components/schemas/JwsAlgorithm"
             },
             "minItems": 1
+          },
+          "validity": {
+            "$ref": "#/components/schemas/Duration"
           }
         },
         "required": [
@@ -405,6 +412,9 @@
               "$ref": "#/components/schemas/JwsAlgorithm"
             },
             "minItems": 1
+          },
+          "validity": {
+            "$ref": "#/components/schemas/Duration"
           }
         },
         "required": [
@@ -429,6 +439,9 @@
               "$ref": "#/components/schemas/JwsAlgorithm"
             },
             "minItems": 1
+          },
+          "validity": {
+            "$ref": "#/components/schemas/Duration"
           }
         },
         "required": [
@@ -452,6 +465,7 @@
         "type": "string",
         "enum": [
           "unsupported_signing_algorithms",
+          "maximum_validity_exceeded",
           "invalid_challenge",
           "invalid_key_attestation",
           "unsupported_attested_key"

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -368,9 +368,6 @@
               "$ref": "#/components/schemas/JwsAlgorithm"
             },
             "minItems": 1
-          },
-          "validity": {
-            "$ref": "#/components/schemas/Duration"
           }
         },
         "required": [
@@ -412,9 +409,6 @@
               "$ref": "#/components/schemas/JwsAlgorithm"
             },
             "minItems": 1
-          },
-          "validity": {
-            "$ref": "#/components/schemas/Duration"
           }
         },
         "required": [
@@ -439,9 +433,6 @@
               "$ref": "#/components/schemas/JwsAlgorithm"
             },
             "minItems": 1
-          },
-          "validity": {
-            "$ref": "#/components/schemas/Duration"
           }
         },
         "required": [
@@ -465,7 +456,6 @@
         "type": "string",
         "enum": [
           "unsupported_signing_algorithms",
-          "maximum_validity_exceeded",
           "invalid_challenge",
           "invalid_key_attestation",
           "unsupported_attested_key"

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -509,6 +509,9 @@
               "$ref": "#/components/schemas/JwsAlgorithm"
             },
             "minItems": 1
+          },
+          "validity": {
+            "$ref": "#/components/schemas/Duration"
           }
         },
         "required": [
@@ -533,6 +536,7 @@
         "type": "string",
         "enum": [
           "unsupported_signing_algorithms",
+          "minimum_validity_not_exceeded",
           "invalid_challenge",
           "invalid_key_attestation",
           "unsupported_attested_key",
@@ -581,6 +585,9 @@
               "$ref": "#/components/schemas/JwsAlgorithm"
             },
             "minItems": 1
+          },
+          "validity": {
+            "$ref": "#/components/schemas/Duration"
           }
         },
         "required": [
@@ -621,6 +628,9 @@
               "$ref": "#/components/schemas/JwsAlgorithm"
             },
             "minItems": 1
+          },
+          "validity": {
+            "$ref": "#/components/schemas/Duration"
           }
         },
         "required": [

--- a/wallet-provider-service/src/main/kotlin/adapter/serialization/Serializers.kt
+++ b/wallet-provider-service/src/main/kotlin/adapter/serialization/Serializers.kt
@@ -23,8 +23,9 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import java.net.URI
 import java.net.URL
+import kotlin.time.Duration
 
-class UriStringSerializer : KSerializer<URI> {
+object UriStringSerializer : KSerializer<URI> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("UriStringSerializer", PrimitiveKind.STRING)
 
     override fun serialize(
@@ -37,7 +38,7 @@ class UriStringSerializer : KSerializer<URI> {
     override fun deserialize(decoder: Decoder): URI = URI.create(decoder.decodeString())
 }
 
-class UrlStringSerializer : KSerializer<URL> {
+object UrlStringSerializer : KSerializer<URL> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("UrlStringSerializer", PrimitiveKind.STRING)
 
     override fun serialize(
@@ -48,4 +49,17 @@ class UrlStringSerializer : KSerializer<URL> {
     }
 
     override fun deserialize(decoder: Decoder): URL = URI.create(decoder.decodeString()).toURL()
+}
+
+object DurationIsoStringSerializer : KSerializer<Duration> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("DurationStringSerializer", PrimitiveKind.STRING)
+
+    override fun serialize(
+        encoder: Encoder,
+        value: Duration,
+    ) {
+        encoder.encodeString(value.toIsoString())
+    }
+
+    override fun deserialize(decoder: Decoder): Duration = Duration.parseIsoString(decoder.decodeString())
 }

--- a/wallet-provider-service/src/main/kotlin/adapter/serialization/Serializers.kt
+++ b/wallet-provider-service/src/main/kotlin/adapter/serialization/Serializers.kt
@@ -24,6 +24,7 @@ import kotlinx.serialization.encoding.Encoder
 import java.net.URI
 import java.net.URL
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 object UriStringSerializer : KSerializer<URI> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("UriStringSerializer", PrimitiveKind.STRING)
@@ -51,15 +52,15 @@ object UrlStringSerializer : KSerializer<URL> {
     override fun deserialize(decoder: Decoder): URL = URI.create(decoder.decodeString()).toURL()
 }
 
-object DurationIsoStringSerializer : KSerializer<Duration> {
-    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("DurationStringSerializer", PrimitiveKind.STRING)
+object DurationSecondsSerializer : KSerializer<Duration> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("DurationSecondsSerializer", PrimitiveKind.LONG)
 
     override fun serialize(
         encoder: Encoder,
         value: Duration,
     ) {
-        encoder.encodeString(value.toIsoString())
+        encoder.encodeLong(value.inWholeSeconds)
     }
 
-    override fun deserialize(decoder: Decoder): Duration = Duration.parseIsoString(decoder.decodeString())
+    override fun deserialize(decoder: Decoder): Duration = decoder.decodeLong().seconds
 }

--- a/wallet-provider-service/src/main/kotlin/config/WalletInstanceAttestationRoutes.kt
+++ b/wallet-provider-service/src/main/kotlin/config/WalletInstanceAttestationRoutes.kt
@@ -85,7 +85,7 @@ private fun Logger.warn(failure: WalletInstanceAttestationIssuanceFailure) {
                     null
             }
 
-            is WalletInstanceAttestationIssuanceFailure.ValidityExceedsMaxAllowsValue -> {
+            is WalletInstanceAttestationIssuanceFailure.ValidityExceedsMaximumAllowedValue -> {
                 "WalletInstanceAttestationIssuanceRequest validation failed, " +
                     "Requested validity exceeds maximum allowed value. Requested: ${failure.requested.toIsoString()}, " +
                     "maximum allowed: ${failure.maximumAllowed.toIsoString()}" to
@@ -157,7 +157,7 @@ private fun WalletInstanceAttestationIssuanceFailure.toWalletInstanceAttestation
             WalletInstanceAttestationError.UnsupportedSigningAlgorithms
         }
 
-        is WalletInstanceAttestationIssuanceFailure.ValidityExceedsMaxAllowsValue -> {
+        is WalletInstanceAttestationIssuanceFailure.ValidityExceedsMaximumAllowedValue -> {
             WalletInstanceAttestationError.MaximumValidityExceeded
         }
 

--- a/wallet-provider-service/src/main/kotlin/config/WalletInstanceAttestationRoutes.kt
+++ b/wallet-provider-service/src/main/kotlin/config/WalletInstanceAttestationRoutes.kt
@@ -85,6 +85,13 @@ private fun Logger.warn(failure: WalletInstanceAttestationIssuanceFailure) {
                     null
             }
 
+            is WalletInstanceAttestationIssuanceFailure.ValidityExceedsMaxAllowsValue -> {
+                "WalletInstanceAttestationIssuanceRequest validation failed, " +
+                    "Requested validity exceeds maximum allowed value. Requested: ${failure.requested.toIsoString()}, " +
+                    "maximum allowed: ${failure.maximumAllowed.toIsoString()}" to
+                    null
+            }
+
             is WalletInstanceAttestationIssuanceFailure.InvalidChallenge -> {
                 "WalletInstanceAttestationIssuanceRequest validation failed, " +
                     "Challenge is not valid: ${failure.error}" to
@@ -126,6 +133,9 @@ private enum class WalletInstanceAttestationError {
     @SerialName("unsupported_signing_algorithms")
     UnsupportedSigningAlgorithms,
 
+    @SerialName("maximum_validity_exceeded")
+    MaximumValidityExceeded,
+
     @SerialName("invalid_challenge")
     InvalidChallenge,
 
@@ -145,6 +155,10 @@ private fun WalletInstanceAttestationIssuanceFailure.toWalletInstanceAttestation
     when (this) {
         is WalletInstanceAttestationIssuanceFailure.UnsupportedSigningAlgorithms -> {
             WalletInstanceAttestationError.UnsupportedSigningAlgorithms
+        }
+
+        is WalletInstanceAttestationIssuanceFailure.ValidityExceedsMaxAllowsValue -> {
+            WalletInstanceAttestationError.MaximumValidityExceeded
         }
 
         is WalletInstanceAttestationIssuanceFailure.InvalidChallenge -> {

--- a/wallet-provider-service/src/main/kotlin/config/WalletInstanceAttestationRoutes.kt
+++ b/wallet-provider-service/src/main/kotlin/config/WalletInstanceAttestationRoutes.kt
@@ -85,13 +85,6 @@ private fun Logger.warn(failure: WalletInstanceAttestationIssuanceFailure) {
                     null
             }
 
-            is WalletInstanceAttestationIssuanceFailure.ValidityExceedsMaximumAllowedValue -> {
-                "WalletInstanceAttestationIssuanceRequest validation failed, " +
-                    "Requested validity exceeds maximum allowed value. Requested: ${failure.requested.toIsoString()}, " +
-                    "maximum allowed: ${failure.maximumAllowed.toIsoString()}" to
-                    null
-            }
-
             is WalletInstanceAttestationIssuanceFailure.InvalidChallenge -> {
                 "WalletInstanceAttestationIssuanceRequest validation failed, " +
                     "Challenge is not valid: ${failure.error}" to
@@ -133,9 +126,6 @@ private enum class WalletInstanceAttestationError {
     @SerialName("unsupported_signing_algorithms")
     UnsupportedSigningAlgorithms,
 
-    @SerialName("maximum_validity_exceeded")
-    MaximumValidityExceeded,
-
     @SerialName("invalid_challenge")
     InvalidChallenge,
 
@@ -155,10 +145,6 @@ private fun WalletInstanceAttestationIssuanceFailure.toWalletInstanceAttestation
     when (this) {
         is WalletInstanceAttestationIssuanceFailure.UnsupportedSigningAlgorithms -> {
             WalletInstanceAttestationError.UnsupportedSigningAlgorithms
-        }
-
-        is WalletInstanceAttestationIssuanceFailure.ValidityExceedsMaximumAllowedValue -> {
-            WalletInstanceAttestationError.MaximumValidityExceeded
         }
 
         is WalletInstanceAttestationIssuanceFailure.InvalidChallenge -> {

--- a/wallet-provider-service/src/main/kotlin/config/WalletProviderApplicationConfiguration.kt
+++ b/wallet-provider-service/src/main/kotlin/config/WalletProviderApplicationConfiguration.kt
@@ -43,6 +43,7 @@ import eu.europa.ec.eudi.walletprovider.domain.walletinformation.WalletSecureCry
 import eu.europa.ec.eudi.walletprovider.port.input.challenge.GenerateChallengeLive
 import eu.europa.ec.eudi.walletprovider.port.input.walletinstanceattestation.IssueWalletInstanceAttestationLive
 import eu.europa.ec.eudi.walletprovider.port.input.walletunitattestation.IssueWalletUnitAttestationLive
+import eu.europa.ec.eudi.walletprovider.port.input.walletunitattestation.WalletUnitAttestationValidity
 import eu.europa.ec.eudi.walletprovider.port.output.challenge.ValidateChallengeLive
 import eu.europa.ec.eudi.walletprovider.port.output.challenge.ValidateChallengeNoop
 import io.ktor.client.*
@@ -157,7 +158,7 @@ suspend fun Application.configureWalletProviderApplication(config: WalletProvide
             clock,
             validateChallenge,
             validateKeyAttestation,
-            config.walletUnitAttestation.validity,
+            WalletUnitAttestationValidity(config.walletUnitAttestation.validity.closedRange),
             generateStatusListToken,
             issuer = config.issuer.publicUrl,
             clientId = config.clientId,

--- a/wallet-provider-service/src/main/kotlin/config/WalletProviderConfiguration.kt
+++ b/wallet-provider-service/src/main/kotlin/config/WalletProviderConfiguration.kt
@@ -253,7 +253,7 @@ data class WalletSecureCryptographicDeviceInformationConfiguration(
 )
 
 data class WalletInstanceAttestationConfiguration(
-    val validity: WalletInstanceAttestationValidity = WalletInstanceAttestationValidity.ArfMax,
+    val validity: WalletInstanceAttestationValidity = WalletInstanceAttestationValidity.Default,
     val walletName: WalletName? = null,
     val walletLink: WalletLink? = null,
 )

--- a/wallet-provider-service/src/main/kotlin/config/WalletProviderConfiguration.kt
+++ b/wallet-provider-service/src/main/kotlin/config/WalletProviderConfiguration.kt
@@ -259,11 +259,18 @@ data class WalletInstanceAttestationConfiguration(
 )
 
 data class WalletUnitAttestationConfiguration(
-    val validity: WalletUnitAttestationValidity = WalletUnitAttestationValidity.ArfMin,
+    val validity: ValidityConfiguration = ValidityConfiguration(),
     val keyStorage: List<AttackPotentialResistance>? = null,
     val userAuthentication: List<AttackPotentialResistance>? = null,
     val certification: StringUrl? = null,
-)
+) {
+    data class ValidityConfiguration(
+        val minimum: Duration = ARF.MIN_WALLET_UNIT_ATTESTATION_VALIDITY,
+        val maximum: Duration = ARF.MIN_WALLET_UNIT_ATTESTATION_VALIDITY * 2,
+    ) {
+        val closedRange: ClosedRange<Duration> = minimum..maximum
+    }
+}
 
 data class TokenStatusListServiceConfiguration(
     val serviceUrl: StringUrl,

--- a/wallet-provider-service/src/main/kotlin/config/WalletUnitAttestationRoutes.kt
+++ b/wallet-provider-service/src/main/kotlin/config/WalletUnitAttestationRoutes.kt
@@ -87,6 +87,14 @@ private fun Logger.warn(failure: WalletUnitAttestationIssuanceFailure) {
             )
         }
 
+        is WalletUnitAttestationIssuanceFailure.ValidityDoesNotExceedMinimumAllowedValue -> {
+            warn(
+                "WalletUnitAttestationIssuanceRequest validation failed, " +
+                    "validity does not exceed minimum allowed value. Requested: ${failure.requested.toIsoString()}, " +
+                    "minimum allowed: ${failure.minimumAllowed.toIsoString()}",
+            )
+        }
+
         is WalletUnitAttestationIssuanceFailure.InvalidChallenge -> {
             warn(
                 "WalletUnitAttestationIssuanceRequest validation failed, Challenge is not valid: ${failure.error}",
@@ -146,6 +154,9 @@ private enum class WalletUnitAttestationError {
     @SerialName("unsupported_signing_algorithms")
     UnsupportedSigningAlgorithms,
 
+    @SerialName("minimum_validity_not_exceeded")
+    MinimumValidityNotExceeded,
+
     @SerialName("invalid_challenge")
     InvalidChallenge,
 
@@ -174,6 +185,10 @@ private fun WalletUnitAttestationIssuanceFailure.toWalletUnitAttestationErrorRes
     when (this) {
         is WalletUnitAttestationIssuanceFailure.UnsupportedSigningAlgorithms -> {
             nonEmptyListOf(WalletUnitAttestationError.UnsupportedSigningAlgorithms)
+        }
+
+        is WalletUnitAttestationIssuanceFailure.ValidityDoesNotExceedMinimumAllowedValue -> {
+            nonEmptyListOf(WalletUnitAttestationError.MinimumValidityNotExceeded)
         }
 
         is WalletUnitAttestationIssuanceFailure.InvalidChallenge -> {

--- a/wallet-provider-service/src/main/kotlin/config/WalletUnitAttestationRoutes.kt
+++ b/wallet-provider-service/src/main/kotlin/config/WalletUnitAttestationRoutes.kt
@@ -87,11 +87,11 @@ private fun Logger.warn(failure: WalletUnitAttestationIssuanceFailure) {
             )
         }
 
-        is WalletUnitAttestationIssuanceFailure.ValidityDoesNotExceedMinimumAllowedValue -> {
+        is WalletUnitAttestationIssuanceFailure.InvalidPreferredTtl -> {
             warn(
                 "WalletUnitAttestationIssuanceRequest validation failed, " +
-                    "validity does not exceed minimum allowed value. Requested: ${failure.requested.toIsoString()}, " +
-                    "minimum allowed: ${failure.minimumAllowed.toIsoString()}",
+                    "preferred ttl is not valid. Requested: ${failure.requested}, " +
+                    "minimum allowed: ${failure.minimumAllowed}, maximum allowed: ${failure.maximumAllowed}",
             )
         }
 
@@ -154,8 +154,8 @@ private enum class WalletUnitAttestationError {
     @SerialName("unsupported_signing_algorithms")
     UnsupportedSigningAlgorithms,
 
-    @SerialName("minimum_validity_not_exceeded")
-    MinimumValidityNotExceeded,
+    @SerialName("invalid_preferred_ttl")
+    InvalidPreferredTtl,
 
     @SerialName("invalid_challenge")
     InvalidChallenge,
@@ -187,8 +187,8 @@ private fun WalletUnitAttestationIssuanceFailure.toWalletUnitAttestationErrorRes
             nonEmptyListOf(WalletUnitAttestationError.UnsupportedSigningAlgorithms)
         }
 
-        is WalletUnitAttestationIssuanceFailure.ValidityDoesNotExceedMinimumAllowedValue -> {
-            nonEmptyListOf(WalletUnitAttestationError.MinimumValidityNotExceeded)
+        is WalletUnitAttestationIssuanceFailure.InvalidPreferredTtl -> {
+            nonEmptyListOf(WalletUnitAttestationError.InvalidPreferredTtl)
         }
 
         is WalletUnitAttestationIssuanceFailure.InvalidChallenge -> {

--- a/wallet-provider-service/src/main/kotlin/domain/Specs.kt
+++ b/wallet-provider-service/src/main/kotlin/domain/Specs.kt
@@ -48,7 +48,6 @@ object ARF {
     const val WALLET_SOLUTION_ID: String = "wallet_solution_id"
     const val WALLET_SOLUTION_VERSION: String = "wallet_solution_version"
     const val WALLET_SOLUTION_CERTIFICATION_INFORMATION: String = "wallet_solution_certification_information"
-    val MAX_WALLET_APPLICATION_ATTESTATION_VALIDITY: Duration = 24.hours
     val MIN_WALLET_UNIT_ATTESTATION_VALIDITY: Duration = 31.days
 
     const val WALLET_SECURE_CRYPTOGRAPHIC_DEVICE_INFORMATION: String = "wscd_info"

--- a/wallet-provider-service/src/main/kotlin/domain/Specs.kt
+++ b/wallet-provider-service/src/main/kotlin/domain/Specs.kt
@@ -58,6 +58,8 @@ object ARF {
     const val WALLET_SECURE_CRYPTOGRAPHIC_DEVICE_TYPE_LOCAL_NATIVE: String = "LOCAL_NATIVE"
     const val WALLET_SECURE_CRYPTOGRAPHIC_DEVICE_TYPE_HYBRID: String = "HYBRID"
     const val WALLET_SECURE_CRYPTOGRAPHIC_CERTIFICATION_INFORMATION: String = "wscd_certification_information"
+
+    const val PREFERRED_TTL: String = "preferred_ttl"
 }
 
 object TokenStatusListSpec {

--- a/wallet-provider-service/src/main/kotlin/domain/Types.kt
+++ b/wallet-provider-service/src/main/kotlin/domain/Types.kt
@@ -17,7 +17,7 @@ package eu.europa.ec.eudi.walletprovider.domain
 
 import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
 import at.asitplus.signum.indispensable.josef.io.InstantLongSerializer
-import eu.europa.ec.eudi.walletprovider.adapter.serialization.DurationIsoStringSerializer
+import eu.europa.ec.eudi.walletprovider.adapter.serialization.DurationSecondsSerializer
 import eu.europa.ec.eudi.walletprovider.adapter.serialization.UriStringSerializer
 import eu.europa.ec.eudi.walletprovider.adapter.serialization.UrlStringSerializer
 import kotlinx.serialization.Serializable
@@ -88,6 +88,6 @@ value class Challenge(
     override fun toString(): String = value.toString()
 }
 
-typealias IsoStringDuration =
-    @Serializable(with = DurationIsoStringSerializer::class)
+typealias SecondsDuration =
+    @Serializable(with = DurationSecondsSerializer::class)
     Duration

--- a/wallet-provider-service/src/main/kotlin/domain/Types.kt
+++ b/wallet-provider-service/src/main/kotlin/domain/Types.kt
@@ -17,11 +17,13 @@ package eu.europa.ec.eudi.walletprovider.domain
 
 import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
 import at.asitplus.signum.indispensable.josef.io.InstantLongSerializer
+import eu.europa.ec.eudi.walletprovider.adapter.serialization.DurationIsoStringSerializer
 import eu.europa.ec.eudi.walletprovider.adapter.serialization.UriStringSerializer
 import eu.europa.ec.eudi.walletprovider.adapter.serialization.UrlStringSerializer
 import kotlinx.serialization.Serializable
 import java.net.URI
 import java.net.URL
+import kotlin.time.Duration
 import kotlin.time.Instant
 
 typealias Base64UrlSafeByteArray =
@@ -85,3 +87,7 @@ value class Challenge(
 
     override fun toString(): String = value.toString()
 }
+
+typealias IsoStringDuration =
+    @Serializable(with = DurationIsoStringSerializer::class)
+    Duration

--- a/wallet-provider-service/src/main/kotlin/port/input/walletinstanceattestation/IssueWalletInstanceAttestation.kt
+++ b/wallet-provider-service/src/main/kotlin/port/input/walletinstanceattestation/IssueWalletInstanceAttestation.kt
@@ -41,6 +41,7 @@ import eu.europa.ec.eudi.walletprovider.port.output.keyattestation.ValidateKeyAt
 import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
 
 fun interface IssueWalletInstanceAttestation {
     suspend operator fun invoke(
@@ -98,14 +99,13 @@ value class WalletInstanceAttestationValidity(
     val value: Duration,
 ) {
     init {
-        require(value.isPositive() && value <= ARF.MAX_WALLET_APPLICATION_ATTESTATION_VALIDITY)
+        require(value.isPositive())
     }
 
     override fun toString(): String = value.toString()
 
     companion object {
-        val ArfMax: WalletInstanceAttestationValidity =
-            WalletInstanceAttestationValidity(ARF.MAX_WALLET_APPLICATION_ATTESTATION_VALIDITY)
+        val Default: WalletInstanceAttestationValidity = WalletInstanceAttestationValidity(5.minutes)
     }
 }
 

--- a/wallet-provider-service/src/main/kotlin/port/input/walletinstanceattestation/IssueWalletInstanceAttestation.kt
+++ b/wallet-provider-service/src/main/kotlin/port/input/walletinstanceattestation/IssueWalletInstanceAttestation.kt
@@ -88,7 +88,7 @@ sealed interface WalletInstanceAttestationIssuanceFailure {
         val requestedSigningAlgorithms: NonEmptyList<JwsAlgorithm>,
     ) : WalletInstanceAttestationIssuanceFailure
 
-    data class ValidityExceedsMaxAllowsValue(
+    data class ValidityExceedsMaximumAllowedValue(
         val requested: Duration,
         val maximumAllowed: Duration,
     ) : WalletInstanceAttestationIssuanceFailure
@@ -167,7 +167,7 @@ class IssueWalletInstanceAttestationLive(
             val validity =
                 request.validity?.let {
                     ensure(it <= validity.value) {
-                        WalletInstanceAttestationIssuanceFailure.ValidityExceedsMaxAllowsValue(
+                        WalletInstanceAttestationIssuanceFailure.ValidityExceedsMaximumAllowedValue(
                             requested = it,
                             maximumAllowed = validity.value,
                         )


### PR DESCRIPTION
This PR introduces a new optional parameter, named `preferred_ttl`, in WUA issuance requests. 

Using this parameter a Wallet can request a specific validity for the issued WUA.

`preferred_ttl` must be between `WALLETUNITATTESTATION_VALIDITY_MINIMUM` and `WALLETUNITATTESTATION_VALIDITY_MAXIMUM`

Default `WALLETUNITATTESTATION_VALIDITY_MINIMUM` is set per TS3 to 31 days.
Default `WALLETUNITATTESTATION_VALIDITY_MAXIMUM` is set to 62 days.

Closes #28 