### PR TITLE
Simplify Swager UI configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,13 +499,7 @@ Wallet Provider exposes an OpenAPI specification of its endpoints using Swagger 
 
 Variable: `SWAGGERUI_PATH`  
 Description: The path at which Swagger UI is exposed.      
-Default value: `/swagger`  
-
-Variable: `SWAGGERUI_SWAGGERFILE`  
-Description: The location of the OpenAPI specification file to serve.      
-Default value: `openapi/openapi.json`  
-
-To disable Swagger UI, set the environment variable `SWAGGERUI` to `Disabled`.  
+Default value: `/swagger`
 
 ### Duration formats
 

--- a/wallet-provider-service/build.gradle.kts
+++ b/wallet-provider-service/build.gradle.kts
@@ -123,20 +123,6 @@ kotlin {
     }
 }
 
-val copyOpenApiSpecification =
-    tasks.register<Copy>("copyOpenApiSpecification") {
-        val processResources = tasks.processResources.get()
-        dependsOn(processResources)
-
-        from(rootProject.layout.projectDirectory.dir("openapi"))
-        include("openapi.json")
-        into(processResources.destinationDir)
-    }
-
-tasks.classes {
-    dependsOn(copyOpenApiSpecification)
-}
-
 spotless {
     kotlin {
         ktlint(libs.versions.ktlint.get())
@@ -161,7 +147,7 @@ jib {
 
     container {
         labels =
-            buildMap<String, String> {
+            buildMap {
                 fun fromEnvironmentVariable(
                     variable: String,
                     label: String,

--- a/wallet-provider-service/src/main/kotlin/config/WalletProviderConfiguration.kt
+++ b/wallet-provider-service/src/main/kotlin/config/WalletProviderConfiguration.kt
@@ -49,7 +49,7 @@ data class WalletProviderConfiguration(
     val walletInstanceAttestation: WalletInstanceAttestationConfiguration = WalletInstanceAttestationConfiguration(),
     val walletUnitAttestation: WalletUnitAttestationConfiguration = WalletUnitAttestationConfiguration(),
     val tokenStatusListService: TokenStatusListServiceConfiguration,
-    val swaggerUi: SwaggerUiConfiguration = SwaggerUiConfiguration.Enabled(),
+    val swaggerUi: SwaggerUiConfiguration = SwaggerUiConfiguration(),
 )
 
 data class ServerConfiguration(
@@ -259,14 +259,9 @@ data class IssuerConfiguration(
     val name: Name = Name("Wallet Provider"),
 )
 
-sealed interface SwaggerUiConfiguration {
-    data object Disabled : SwaggerUiConfiguration
-
-    data class Enabled(
-        val path: NonBlankString = "/swagger".toNonBlankString(),
-        val swaggerFile: NonBlankString = "openapi/openapi.json".toNonBlankString(),
-    ) : SwaggerUiConfiguration
-}
+data class SwaggerUiConfiguration(
+    val path: NonBlankString = "/swagger".toNonBlankString(),
+)
 
 enum class SigningAlgorithm {
     ES256,

--- a/wallet-provider-service/src/main/kotlin/config/WalletProviderModuleConfiguration.kt
+++ b/wallet-provider-service/src/main/kotlin/config/WalletProviderModuleConfiguration.kt
@@ -188,12 +188,10 @@ private fun Application.configureServerPlugins(
     install(XForwardedHeaders)
     install(ForwardedHeaders)
 
-    if (swaggerUiConfiguration is SwaggerUiConfiguration.Enabled) {
-        routing {
-            swaggerUI(path = swaggerUiConfiguration.path.value, swaggerFile = swaggerUiConfiguration.swaggerFile.value)
-            get("/") {
-                call.respondRedirect(swaggerUiConfiguration.path.value)
-            }
+    routing {
+        swaggerUI(path = swaggerUiConfiguration.path.value, swaggerFile = "openapi/openapi.json")
+        get("/") {
+            call.respondRedirect(swaggerUiConfiguration.path.value)
         }
     }
 }

--- a/wallet-provider-service/src/test/kotlin/WalletProviderTest.kt
+++ b/wallet-provider-service/src/test/kotlin/WalletProviderTest.kt
@@ -117,7 +117,6 @@ private class WalletProviderExtension :
                             serviceUrl = URI.create("https://status.example.com/create").toURL(),
                             apiKey = Secret("API-KEY"),
                         ),
-                    swaggerUi = SwaggerUiConfiguration.Enabled(swaggerFile = "../openapi/openapi.json".toNonBlankString()),
                 )
 
             val clock = Clock.System


### PR DESCRIPTION
This PR simplifies Swagger UI configuration.

1. Swagger UI can no longer be disabled;
2. Swagger File location can no longer be overridden, i.e. the user cannot serve a custom OpenAPI specification;
3. Build script has been cleaned up;