### PR TITLE
Update WIA claims-set per TS3 v1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ Description: Optional Wallet Link that can be included in the Wallet Instance At
 Default value: N/A  
 
 Variable: `WALLETINSTANCEATTESTATION_WALLETVERSION`  
-Description: Optional Wallet Version that can be included in the Wallet Instance Attestations.  
+Description: Wallet Version that will be included in the Wallet Instance Attestations.  
 Default value: N/A
 
 Variable: `WALLETINSTANCEATTESTATION_WALLETCERTIFICATIONINFORMATION`  

--- a/README.md
+++ b/README.md
@@ -443,8 +443,20 @@ Description: Wallet Name that will be included in the Wallet Instance Attestatio
 Default value: N/A  
 
 Variable: `WALLETINSTANCEATTESTATION_WALLETLINK`  
-Description: Wallet Link that will be included in the Wallet Instance Attestations.  
+Description: Optional Wallet Link that can be included in the Wallet Instance Attestations.  
 Default value: N/A  
+
+Variable: `WALLETINSTANCEATTESTATION_WALLETVERSION`  
+Description: Optional Wallet Version that can be included in the Wallet Instance Attestations.  
+Default value: N/A
+
+Variable: `WALLETINSTANCEATTESTATION_WALLETCERTIFICATIONINFORMATION`  
+Description: Wallet Certification Information that will be included in the Wallet Instance Attestations.  
+Default value: N/A
+
+Variable: `WALLETINSTANCEATTESTATION_CLIENTSTATUSVALIDITY`  
+Description: Duration a Client Status of a Wallet Instance Attestation is valid for.  
+Default value: `90 days`
 
 ### Wallet Unit Attestation Configuration
 

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -481,7 +481,8 @@
           "invalid_key_attestation",
           "unsupported_attested_key",
           "unsupported_attested_key_type",
-          "unsupported_attested_key_curve"
+          "unsupported_attested_key_curve",
+          "status_list_token_generation_failure"
         ]
       },
       "WalletInstanceAttestationErrorResponse": {

--- a/wallet-provider-service/src/main/kotlin/config/WalletInstanceAttestationRoutes.kt
+++ b/wallet-provider-service/src/main/kotlin/config/WalletInstanceAttestationRoutes.kt
@@ -20,6 +20,7 @@ import eu.europa.ec.eudi.walletprovider.port.input.walletinstanceattestation.Iss
 import eu.europa.ec.eudi.walletprovider.port.input.walletinstanceattestation.WalletInstanceAttestationIssuanceFailure
 import eu.europa.ec.eudi.walletprovider.port.input.walletinstanceattestation.WalletInstanceAttestationIssuanceRequest
 import eu.europa.ec.eudi.walletprovider.port.output.keyattestation.KeyAttestationValidationFailure
+import eu.europa.ec.eudi.walletprovider.port.output.tokenstatuslist.StatusListTokenGenerationFailure
 import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.request.*
@@ -118,6 +119,15 @@ private fun Logger.warn(failure: WalletInstanceAttestationIssuanceFailure) {
                     "Attested Key Curve is not supported: ${failure.curve.name}" to
                     null
             }
+
+            is WalletInstanceAttestationIssuanceFailure.StatusListTokenGenerationFailure -> {
+                when (failure.error) {
+                    is StatusListTokenGenerationFailure.Unexpected -> {
+                        "WalletInstanceAttestationIssuanceRequest failed, unable to generate Status List Token" to
+                            failure.error.cause
+                    }
+                }
+            }
         }
 
     warn(error, cause)
@@ -152,6 +162,9 @@ private enum class WalletInstanceAttestationError {
 
     @SerialName("unsupported_attested_key_curve")
     UnsupportedAttestedKeyCurve,
+
+    @SerialName("status_list_token_generation_failure")
+    StatusListTokenGenerationFailure,
 }
 
 @Serializable
@@ -182,5 +195,9 @@ private fun WalletInstanceAttestationIssuanceFailure.toWalletInstanceAttestation
 
         is WalletInstanceAttestationIssuanceFailure.UnsupportedAttestedKeyCurve -> {
             WalletInstanceAttestationError.UnsupportedAttestedKeyCurve
+        }
+
+        is WalletInstanceAttestationIssuanceFailure.StatusListTokenGenerationFailure -> {
+            WalletInstanceAttestationError.StatusListTokenGenerationFailure
         }
     }.let { WalletInstanceAttestationErrorResponse(it) }

--- a/wallet-provider-service/src/main/kotlin/config/WalletProviderConfiguration.kt
+++ b/wallet-provider-service/src/main/kotlin/config/WalletProviderConfiguration.kt
@@ -24,15 +24,16 @@ import eu.europa.ec.eudi.walletprovider.domain.*
 import eu.europa.ec.eudi.walletprovider.domain.walletinformation.*
 import eu.europa.ec.eudi.walletprovider.domain.walletinstanceattestation.WalletLink
 import eu.europa.ec.eudi.walletprovider.domain.walletinstanceattestation.WalletName
+import eu.europa.ec.eudi.walletprovider.domain.walletinstanceattestation.WalletVersion
 import eu.europa.ec.eudi.walletprovider.domain.walletunitattestation.AttackPotentialResistance
 import eu.europa.ec.eudi.walletprovider.port.input.challenge.Length
-import eu.europa.ec.eudi.walletprovider.port.input.challenge.PositiveDuration
 import eu.europa.ec.eudi.walletprovider.port.input.walletinstanceattestation.WalletInstanceAttestationValidity
 import kotlinx.serialization.json.JsonPrimitive
 import java.nio.file.Path
 import kotlin.io.encoding.Base64
 import kotlin.reflect.KType
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
@@ -46,7 +47,7 @@ data class WalletProviderConfiguration(
     val issuer: IssuerConfiguration = IssuerConfiguration(),
     val clientId: ClientId = ClientId("wallet-dev"),
     val walletInformation: WalletInformationConfiguration,
-    val walletInstanceAttestation: WalletInstanceAttestationConfiguration = WalletInstanceAttestationConfiguration(),
+    val walletInstanceAttestation: WalletInstanceAttestationConfiguration,
     val walletUnitAttestation: WalletUnitAttestationConfiguration = WalletUnitAttestationConfiguration(),
     val tokenStatusListService: TokenStatusListServiceConfiguration,
     val swaggerUi: SwaggerUiConfiguration = SwaggerUiConfiguration(),
@@ -231,8 +232,11 @@ data class WalletSecureCryptographicDeviceInformationConfiguration(
 
 data class WalletInstanceAttestationConfiguration(
     val validity: WalletInstanceAttestationValidity = WalletInstanceAttestationValidity.Default,
-    val walletName: WalletName? = null,
+    val walletName: WalletName,
     val walletLink: WalletLink? = null,
+    val walletVersion: WalletVersion,
+    val walletCertificationInformation: CertificationInformation,
+    val clientStatusValidity: PositiveDuration = PositiveDuration(90.days),
 )
 
 data class WalletUnitAttestationConfiguration(

--- a/wallet-provider-service/src/main/kotlin/config/WalletProviderModuleConfiguration.kt
+++ b/wallet-provider-service/src/main/kotlin/config/WalletProviderModuleConfiguration.kt
@@ -103,6 +103,14 @@ fun Application.configureWalletProviderModule(
     val makotoAttestationService = createMakotoAttestationService(config, clock)
     val validateKeyAttestation = MakotoValidateKeyAttestation(makotoAttestationService)
 
+    val generateStatusListToken =
+        TokenStatusListServiceGenerateStatusListToken(
+            httpClient,
+            Url(config.tokenStatusListService.serviceUrl.toExternalForm()),
+            ApiKey(config.tokenStatusListService.apiKey.value),
+            clock,
+        )
+
     val issueWalletInstanceAttestation =
         IssueWalletInstanceAttestationLive(
             clock,
@@ -111,28 +119,18 @@ fun Application.configureWalletProviderModule(
             config.walletInstanceAttestation.validity,
             issuer = config.issuer.publicUrl,
             clientId = config.clientId,
-            config.walletInstanceAttestation.walletName,
+            walletName = config.walletInstanceAttestation.walletName,
             config.walletInstanceAttestation.walletLink,
-            GeneralInformation(
-                provider = config.walletInformation.generalInformation.provider,
-                id = config.walletInformation.generalInformation.id,
-                version = config.walletInformation.generalInformation.version,
-                certification = config.walletInformation.generalInformation.certification,
-            ),
+            walletVersion = config.walletInstanceAttestation.walletVersion,
+            config.walletInstanceAttestation.walletCertificationInformation,
+            config.walletInstanceAttestation.clientStatusValidity,
+            generateStatusListToken,
             SignumSignJwt(
                 signer,
                 certificateChain,
                 JwtType(AttestationBasedClientAuthenticationSpec.CLIENT_ATTESTATION_JWT_TYPE),
                 json,
             ),
-        )
-
-    val generateStatusListToken =
-        TokenStatusListServiceGenerateStatusListToken(
-            httpClient,
-            Url(config.tokenStatusListService.serviceUrl.toExternalForm()),
-            ApiKey(config.tokenStatusListService.apiKey.value),
-            clock,
         )
 
     val issueWalletUnitAttestation =

--- a/wallet-provider-service/src/main/kotlin/domain/Specs.kt
+++ b/wallet-provider-service/src/main/kotlin/domain/Specs.kt
@@ -47,7 +47,6 @@ object ARF {
     const val WALLET_PROVIDER_NAME: String = "wallet_provider_name"
     const val WALLET_SOLUTION_ID: String = "wallet_solution_id"
     const val WALLET_SOLUTION_VERSION: String = "wallet_solution_version"
-    const val WALLET_SOLUTION_CERTIFICATION_INFORMATION: String = "wallet_solution_certification_information"
     val MIN_WALLET_UNIT_ATTESTATION_VALIDITY: Duration = 31.days
     val MAX_WALLET_INSTANCE_ATTESTATION_VALIDITY: Duration = 24.hours
 
@@ -107,4 +106,10 @@ object RFC9728 {
  */
 object CustomFields {
     const val WALLET_METADATA: String = "wallet_metadata"
+}
+
+object TS3 {
+    const val WALLET_VERSION: String = "wallet_version"
+    const val WALLET_SOLUTION_CERTIFICATION_INFORMATION: String = "wallet_solution_certification_information"
+    const val CLIENT_STATUS: String = "client_status"
 }

--- a/wallet-provider-service/src/main/kotlin/domain/Specs.kt
+++ b/wallet-provider-service/src/main/kotlin/domain/Specs.kt
@@ -108,6 +108,9 @@ object CustomFields {
     const val WALLET_METADATA: String = "wallet_metadata"
 }
 
+/**
+ * [Specification of Wallet Unit Attestations (WUA) used in issuance of PID and Attestations](https://github.com/eu-digital-identity-wallet/eudi-doc-standards-and-technical-specifications/blob/main/docs/technical-specifications/ts3-wallet-unit-attestation.md)
+ */
 object TS3 {
     const val WALLET_VERSION: String = "wallet_version"
     const val WALLET_SOLUTION_CERTIFICATION_INFORMATION: String = "wallet_solution_certification_information"

--- a/wallet-provider-service/src/main/kotlin/domain/Types.kt
+++ b/wallet-provider-service/src/main/kotlin/domain/Types.kt
@@ -79,3 +79,14 @@ typealias JwtType = NonBlankString
 typealias SecondsDuration =
     @Serializable(with = DurationSecondsSerializer::class)
     Duration
+
+@JvmInline
+value class PositiveDuration(
+    val value: Duration,
+) {
+    init {
+        require(value.isPositive()) { "value must be positive" }
+    }
+
+    override fun toString(): String = value.toString()
+}

--- a/wallet-provider-service/src/main/kotlin/domain/walletinformation/WalletInformation.kt
+++ b/wallet-provider-service/src/main/kotlin/domain/walletinformation/WalletInformation.kt
@@ -17,6 +17,7 @@ package eu.europa.ec.eudi.walletprovider.domain.walletinformation
 
 import eu.europa.ec.eudi.walletprovider.domain.ARF
 import eu.europa.ec.eudi.walletprovider.domain.NonBlankString
+import eu.europa.ec.eudi.walletprovider.domain.TS3
 import kotlinx.serialization.Required
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -29,7 +30,7 @@ data class GeneralInformation(
     @Required @SerialName(ARF.WALLET_PROVIDER_NAME) val provider: WalletProviderName,
     @Required @SerialName(ARF.WALLET_SOLUTION_ID) val id: SolutionId,
     @Required @SerialName(ARF.WALLET_SOLUTION_VERSION) val version: SolutionVersion,
-    @Required @SerialName(ARF.WALLET_SOLUTION_CERTIFICATION_INFORMATION) val certification: CertificationInformation,
+    @Required @SerialName(TS3.WALLET_SOLUTION_CERTIFICATION_INFORMATION) val certification: CertificationInformation,
 )
 
 typealias WalletProviderName = NonBlankString

--- a/wallet-provider-service/src/main/kotlin/domain/walletinstanceattestation/WalletInstanceAttestationClaims.kt
+++ b/wallet-provider-service/src/main/kotlin/domain/walletinstanceattestation/WalletInstanceAttestationClaims.kt
@@ -19,6 +19,7 @@ import at.asitplus.signum.indispensable.josef.ConfirmationClaim
 import at.asitplus.signum.indispensable.josef.JwsSigned
 import eu.europa.ec.eudi.walletprovider.domain.*
 import eu.europa.ec.eudi.walletprovider.domain.tokenstatuslist.Status
+import eu.europa.ec.eudi.walletprovider.domain.walletinformation.CertificationInformation
 import eu.europa.ec.eudi.walletprovider.domain.walletinformation.GeneralInformation
 import kotlinx.serialization.Required
 import kotlinx.serialization.SerialName
@@ -33,20 +34,25 @@ data class WalletInstanceAttestationClaims(
     @Required @SerialName(RFC7800.CONFIRMATION) val confirmation: ConfirmationClaim,
     @SerialName(RFC7519.ISSUED_AT) val issuedAt: EpochSecondsInstant? = null,
     @SerialName(RFC7519.NOT_BEFORE) val notBefore: EpochSecondsInstant? = null,
-    @SerialName(OpenId4VCISpec.WALLET_NAME) val walletName: WalletName? = null,
+    @Required @SerialName(OpenId4VCISpec.WALLET_NAME) val walletName: WalletName,
     @SerialName(OpenId4VCISpec.WALLET_LINK) val walletLink: WalletLink? = null,
     @SerialName(TokenStatusListSpec.STATUS) val status: Status? = null,
-    @Required @SerialName(ARF.EUDI_WALLET_INFORMATION) val walletInformation: WalletInformation,
+    @Required @SerialName(TS3.WALLET_VERSION) val walletVersion: WalletVersion,
+    @Required @SerialName(TS3.WALLET_SOLUTION_CERTIFICATION_INFORMATION) val walletSolutionCertificationInformation:
+        CertificationInformation,
+    @Required @SerialName(TS3.CLIENT_STATUS) val clientStatus: ClientStatus,
     @SerialName(CustomFields.WALLET_METADATA) val walletMetadata: WalletMetadata? = null,
-) {
-    @Serializable
-    data class WalletInformation(
-        @Required @SerialName(ARF.GENERAL_INFORMATION) val generalInformation: GeneralInformation,
-    )
-}
+)
+
+@Serializable
+data class ClientStatus(
+    @Required @SerialName(TokenStatusListSpec.STATUS) val status: Status,
+    @Required @SerialName(RFC7519.EXPIRES_AT) val expiresAt: EpochSecondsInstant,
+)
 
 typealias WalletName = NonBlankString
 typealias WalletLink = StringUrl
+typealias WalletVersion = NonBlankString
 
 /**
  * Custom metadata provided by the Wallet to be included in the issued Wallet Instance Attestation.

--- a/wallet-provider-service/src/main/kotlin/port/input/challenge/GenerateChallenge.kt
+++ b/wallet-provider-service/src/main/kotlin/port/input/challenge/GenerateChallenge.kt
@@ -15,6 +15,7 @@
  */
 package eu.europa.ec.eudi.walletprovider.port.input.challenge
 
+import eu.europa.ec.eudi.walletprovider.domain.PositiveDuration
 import eu.europa.ec.eudi.walletprovider.domain.challenge.Challenge
 import eu.europa.ec.eudi.walletprovider.domain.challenge.ChallengeRepository
 import eu.europa.ec.eudi.walletprovider.domain.time.Clock
@@ -60,17 +61,6 @@ value class Length(
         require(value.toInt() in Challenge.MIN_LENGTH..Challenge.MAX_LENGTH) {
             "value must be between ${Challenge.MIN_LENGTH} and ${Challenge.MAX_LENGTH}"
         }
-    }
-
-    override fun toString(): String = value.toString()
-}
-
-@JvmInline
-value class PositiveDuration(
-    val value: Duration,
-) {
-    init {
-        require(value.isPositive()) { "value must be positive" }
     }
 
     override fun toString(): String = value.toString()

--- a/wallet-provider-service/src/main/kotlin/port/input/walletinstanceattestation/IssueWalletInstanceAttestation.kt
+++ b/wallet-provider-service/src/main/kotlin/port/input/walletinstanceattestation/IssueWalletInstanceAttestation.kt
@@ -17,6 +17,7 @@ package eu.europa.ec.eudi.walletprovider.port.input.walletinstanceattestation
 
 import arrow.core.Either
 import arrow.core.NonEmptyList
+import arrow.core.raise.context.bind
 import arrow.core.raise.either
 import arrow.core.raise.ensure
 import arrow.core.serialization.NonEmptyListSerializer
@@ -27,12 +28,16 @@ import at.asitplus.signum.indispensable.IosHomebrewAttestation
 import at.asitplus.signum.indispensable.josef.*
 import eu.europa.ec.eudi.walletprovider.domain.*
 import eu.europa.ec.eudi.walletprovider.domain.time.Clock
+import eu.europa.ec.eudi.walletprovider.domain.tokenstatuslist.Status
+import eu.europa.ec.eudi.walletprovider.domain.walletinformation.CertificationInformation
 import eu.europa.ec.eudi.walletprovider.domain.walletinformation.GeneralInformation
 import eu.europa.ec.eudi.walletprovider.domain.walletinstanceattestation.*
+import eu.europa.ec.eudi.walletprovider.port.input.walletunitattestation.WalletUnitAttestationIssuanceFailure
 import eu.europa.ec.eudi.walletprovider.port.output.challenge.ValidateChallenge
 import eu.europa.ec.eudi.walletprovider.port.output.jose.SignJwt
 import eu.europa.ec.eudi.walletprovider.port.output.keyattestation.KeyAttestationValidationFailure
 import eu.europa.ec.eudi.walletprovider.port.output.keyattestation.ValidateKeyAttestation
+import eu.europa.ec.eudi.walletprovider.port.output.tokenstatuslist.GenerateStatusListToken
 import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 import kotlin.time.Duration
@@ -133,6 +138,10 @@ sealed interface WalletInstanceAttestationIssuanceFailure {
     data class UnsupportedAttestedKeyCurve(
         val curve: ECCurve,
     ) : WalletInstanceAttestationIssuanceFailure
+
+    class StatusListTokenGenerationFailure(
+        val error: eu.europa.ec.eudi.walletprovider.port.output.tokenstatuslist.StatusListTokenGenerationFailure,
+    ) : WalletInstanceAttestationIssuanceFailure
 }
 
 @JvmInline
@@ -160,9 +169,12 @@ class IssueWalletInstanceAttestationLive(
     private val validity: WalletInstanceAttestationValidity,
     private val issuer: Issuer,
     private val clientId: ClientId,
-    private val walletName: WalletName?,
+    private val walletName: WalletName,
     private val walletLink: WalletLink?,
-    private val generalInformation: GeneralInformation,
+    private val walletVersion: WalletVersion,
+    private val walletSolutionCertificationInformation: CertificationInformation,
+    private val clientStatusValidity: PositiveDuration,
+    private val generateStatusListToken: GenerateStatusListToken,
     private val signJwt: SignJwt<WalletInstanceAttestationClaims>,
 ) : IssueWalletInstanceAttestation {
     override suspend fun invoke(
@@ -211,6 +223,16 @@ class IssueWalletInstanceAttestationLive(
 
             val issuedAt = clock.now()
             val expiresAt = issuedAt + validity.value
+            val clientStatus =
+                run {
+                    val clientStatusExpiresAt = issuedAt + clientStatusValidity.value
+                    val statusListToken =
+                        generateStatusListToken(clientStatusExpiresAt)
+                            .mapLeft { WalletInstanceAttestationIssuanceFailure.StatusListTokenGenerationFailure(it) }
+                            .bind()
+                    ClientStatus(Status(statusListToken), clientStatusExpiresAt)
+                }
+
             val walletInstanceAttestation =
                 WalletInstanceAttestationClaims(
                     issuer,
@@ -219,10 +241,12 @@ class IssueWalletInstanceAttestationLive(
                     ConfirmationClaim(jsonWebKey = attestedKey),
                     issuedAt = issuedAt,
                     notBefore = issuedAt,
-                    walletName,
+                    walletName = walletName,
                     walletLink,
                     null,
-                    WalletInstanceAttestationClaims.WalletInformation(generalInformation),
+                    walletVersion = walletVersion,
+                    walletSolutionCertificationInformation,
+                    clientStatus,
                     request.walletMetadata,
                 )
 

--- a/wallet-provider-service/src/test/kotlin/WalletProviderTest.kt
+++ b/wallet-provider-service/src/test/kotlin/WalletProviderTest.kt
@@ -24,6 +24,7 @@ import arrow.fx.coroutines.ExitCase
 import com.sksamuel.hoplite.Secret
 import eu.europa.ec.eudi.walletprovider.adapter.persistence.challenge.Challenges
 import eu.europa.ec.eudi.walletprovider.config.*
+import eu.europa.ec.eudi.walletprovider.domain.NonBlankString
 import eu.europa.ec.eudi.walletprovider.domain.OpenId4VCISpec
 import eu.europa.ec.eudi.walletprovider.domain.time.Clock
 import eu.europa.ec.eudi.walletprovider.domain.toNonBlankString
@@ -111,6 +112,15 @@ private class WalletProviderExtension :
                                 WalletSecureCryptographicDeviceType.LocalNative,
                                 CertificationInformation(JsonPrimitive("ARF")),
                             ),
+                        ),
+                    walletInstanceAttestation =
+                        WalletInstanceAttestationConfiguration(
+                            walletName = "EUDI Wallet".toNonBlankString(),
+                            walletVersion = "1.0.0".toNonBlankString(),
+                            walletCertificationInformation =
+                                CertificationInformation(
+                                    JsonPrimitive("https://github.com/eu-digital-identity-wallet"),
+                                ),
                         ),
                     tokenStatusListService =
                         TokenStatusListServiceConfiguration(


### PR DESCRIPTION
This PR updates the WIA claims-set per TS3 v1.5.

It also updates the configuration properties as needed so that users can configure various claims that are to be included in the WIA claims-set.

Closes #70