### PR TITLE
Add a parameter so that a Wallet can communicate `preferred_client_status_period` during WIA issuance

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -369,6 +369,16 @@
                 "description": "Custom metadata provided by the Wallet to be included in the issued Wallet Instance Attestation"
               }
             ]
+          },
+          "preferredClientStatusPeriod": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SecondsDuration"
+              },
+              {
+                "description": "A PID or Attestation Provider's preference for the remaining status maintenance period"
+              }
+            ]
           }
         },
         "required": [
@@ -420,6 +430,16 @@
                 "description": "Custom metadata provided by the Wallet to be included in the issued Wallet Instance Attestation"
               }
             ]
+          },
+          "preferredClientStatusPeriod": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SecondsDuration"
+              },
+              {
+                "description": "A PID or Attestation Provider's preference for the remaining status maintenance period"
+              }
+            ]
           }
         },
         "required": [
@@ -452,6 +472,16 @@
               },
               {
                 "description": "Custom metadata provided by the Wallet to be included in the issued Wallet Instance Attestation"
+              }
+            ]
+          },
+          "preferredClientStatusPeriod": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SecondsDuration"
+              },
+              {
+                "description": "A PID or Attestation Provider's preference for the remaining status maintenance period"
               }
             ]
           }

--- a/wallet-provider-service/src/main/kotlin/port/input/walletinstanceattestation/IssueWalletInstanceAttestation.kt
+++ b/wallet-provider-service/src/main/kotlin/port/input/walletinstanceattestation/IssueWalletInstanceAttestation.kt
@@ -52,6 +52,7 @@ fun interface IssueWalletInstanceAttestation {
 sealed interface WalletInstanceAttestationIssuanceRequest {
     val supportedSigningAlgorithms: NonEmptyList<JsonWebAlgorithm>?
     val walletMetadata: WalletMetadata?
+    val preferredClientStatusPeriod: SecondsDuration?
 
     sealed interface PlatformKeyAttestation<out KeyAttestation : Attestation> : WalletInstanceAttestationIssuanceRequest {
         val keyAttestation: KeyAttestation
@@ -65,19 +66,22 @@ sealed interface WalletInstanceAttestationIssuanceRequest {
                 with = NonEmptyListSerializer::class,
             ) override val supportedSigningAlgorithms: NonEmptyList<JsonWebAlgorithm>? = null,
             override val walletMetadata: WalletMetadata? = null,
+            override val preferredClientStatusPeriod: SecondsDuration? = null,
         ) : PlatformKeyAttestation<AndroidKeystoreAttestation> {
             override fun equals(other: Any?): Boolean =
                 other is Android &&
                     other.keyAttestation == keyAttestation &&
                     other.challenge.contentEquals(challenge) &&
                     other.supportedSigningAlgorithms == supportedSigningAlgorithms &&
-                    other.walletMetadata == walletMetadata
+                    other.walletMetadata == walletMetadata &&
+                    other.preferredClientStatusPeriod == preferredClientStatusPeriod
 
             override fun hashCode(): Int {
                 var result = keyAttestation.hashCode()
                 result = 31 * result + challenge.contentHashCode()
                 result = 31 * result + (supportedSigningAlgorithms?.hashCode() ?: 0)
                 result = 31 * result + (walletMetadata?.hashCode() ?: 0)
+                result = 31 * result + (preferredClientStatusPeriod?.hashCode() ?: 0)
                 return result
             }
         }
@@ -90,19 +94,22 @@ sealed interface WalletInstanceAttestationIssuanceRequest {
                 with = NonEmptyListSerializer::class,
             ) override val supportedSigningAlgorithms: NonEmptyList<JsonWebAlgorithm>? = null,
             override val walletMetadata: WalletMetadata? = null,
+            override val preferredClientStatusPeriod: SecondsDuration? = null,
         ) : PlatformKeyAttestation<IosHomebrewAttestation> {
             override fun equals(other: Any?): Boolean =
                 other is Ios &&
                     other.keyAttestation == keyAttestation &&
                     other.challenge.contentEquals(challenge) &&
                     other.supportedSigningAlgorithms == supportedSigningAlgorithms &&
-                    other.walletMetadata == walletMetadata
+                    other.walletMetadata == walletMetadata &&
+                    other.preferredClientStatusPeriod == preferredClientStatusPeriod
 
             override fun hashCode(): Int {
                 var result = keyAttestation.hashCode()
                 result = 31 * result + challenge.contentHashCode()
                 result = 31 * result + (supportedSigningAlgorithms?.hashCode() ?: 0)
                 result = 31 * result + (walletMetadata?.hashCode() ?: 0)
+                result = 31 * result + (preferredClientStatusPeriod?.hashCode() ?: 0)
                 return result
             }
         }
@@ -113,6 +120,7 @@ sealed interface WalletInstanceAttestationIssuanceRequest {
         val jwk: JsonWebKey,
         @Serializable(with = NonEmptyListSerializer::class) override val supportedSigningAlgorithms: NonEmptyList<JsonWebAlgorithm>? = null,
         override val walletMetadata: WalletMetadata? = null,
+        override val preferredClientStatusPeriod: SecondsDuration? = null,
     ) : WalletInstanceAttestationIssuanceRequest
 }
 
@@ -225,7 +233,8 @@ class IssueWalletInstanceAttestationLive(
             val expiresAt = issuedAt + validity.value
             val clientStatus =
                 run {
-                    val clientStatusExpiresAt = issuedAt + clientStatusValidity.value
+                    val clientStatusPeriod = maxOf(request.preferredClientStatusPeriod ?: Duration.ZERO, clientStatusValidity.value)
+                    val clientStatusExpiresAt = issuedAt + clientStatusPeriod
                     val statusListToken =
                         generateStatusListToken(clientStatusExpiresAt)
                             .mapLeft { WalletInstanceAttestationIssuanceFailure.StatusListTokenGenerationFailure(it) }

--- a/wallet-provider-service/src/test/kotlin/IssueWalletInstanceAttestationTest.kt
+++ b/wallet-provider-service/src/test/kotlin/IssueWalletInstanceAttestationTest.kt
@@ -18,6 +18,9 @@ package eu.europa.ec.eudi.walletprovider
 import at.asitplus.signum.indispensable.ECCurve
 import at.asitplus.signum.indispensable.josef.toJsonWebKey
 import at.asitplus.signum.supreme.sign.EphemeralKey
+import eu.europa.ec.eudi.walletprovider.config.WalletProviderConfiguration
+import eu.europa.ec.eudi.walletprovider.domain.SecondsDuration
+import eu.europa.ec.eudi.walletprovider.domain.time.Clock
 import eu.europa.ec.eudi.walletprovider.domain.walletinstanceattestation.WalletInstanceAttestation
 import eu.europa.ec.eudi.walletprovider.domain.walletinstanceattestation.WalletInstanceAttestationClaims
 import eu.europa.ec.eudi.walletprovider.domain.walletinstanceattestation.WalletMetadata
@@ -31,6 +34,8 @@ import io.ktor.test.dispatcher.*
 import kotlinx.coroutines.test.TestResult
 import kotlinx.serialization.json.*
 import kotlin.test.*
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
 
 class IssueWalletInstanceAttestationTest : WalletProviderTest() {
     @Test
@@ -41,7 +46,7 @@ class IssueWalletInstanceAttestationTest : WalletProviderTest() {
                 put("app_version", "1.2.3")
             }
 
-        httpClient.runWalletInstanceAttestationTestCase(walletMetadata) {
+        httpClient.runWalletInstanceAttestationTestCase(walletMetadata = walletMetadata) {
             val signedWalletMetadata = assertNotNull(it.payload.walletMetadata)
             assertEquals(walletMetadata, signedWalletMetadata)
         }
@@ -56,7 +61,7 @@ class IssueWalletInstanceAttestationTest : WalletProviderTest() {
                 add("tag3")
             }
 
-        httpClient.runWalletInstanceAttestationTestCase(walletMetadata) {
+        httpClient.runWalletInstanceAttestationTestCase(walletMetadata = walletMetadata) {
             val signedWalletMetadata = assertNotNull(it.payload.walletMetadata)
             assertEquals(walletMetadata, signedWalletMetadata)
         }
@@ -66,22 +71,66 @@ class IssueWalletInstanceAttestationTest : WalletProviderTest() {
     fun `wallet instance attestation includes wallet metadata when provided as primitive`(httpClient: HttpClient) {
         val walletMetadata = JsonPrimitive("simple-string-value")
 
-        httpClient.runWalletInstanceAttestationTestCase(walletMetadata) {
+        httpClient.runWalletInstanceAttestationTestCase(walletMetadata = walletMetadata) {
             val signedWalletMetadata = assertNotNull(it.payload.walletMetadata)
             assertEquals(walletMetadata, signedWalletMetadata)
         }
     }
 
     @Test
-    fun `wallet instance attestation works without wallet metadata for backward compatibility`(httpClient: HttpClient) {
-        httpClient.runWalletInstanceAttestationTestCase(null) {
+    fun `wallet instance attestation works without wallet metadata for backward compatibility`(httpClient: HttpClient) =
+        httpClient.runWalletInstanceAttestationTestCase(walletMetadata = null) {
             assertNull(it.payload.walletMetadata)
+        }
+
+    @Test
+    fun `wallet instance attestation uses configured client status validity when no preference is provided`(
+        httpClient: HttpClient,
+        clock: Clock,
+        config: WalletProviderConfiguration,
+    ) = httpClient.runWalletInstanceAttestationTestCase {
+        val now = clock.now()
+        val clientStatusValidity: Duration = it.payload.clientStatus.expiresAt - now
+        assertTrue(clientStatusValidity <= config.walletInstanceAttestation.clientStatusValidity.value)
+    }
+
+    @Test
+    fun `wallet instance attestation uses configured client status validity when preference is less than configured`(
+        httpClient: HttpClient,
+        clock: Clock,
+        config: WalletProviderConfiguration,
+    ) {
+        val preferredClientStatusPeriod = config.walletInstanceAttestation.clientStatusValidity.value - 5.days
+        check(preferredClientStatusPeriod.isPositive()) { "preferredClientStatusPeriod can't be negative" }
+
+        httpClient.runWalletInstanceAttestationTestCase(preferredClientStatusPeriod = preferredClientStatusPeriod) {
+            val now = clock.now()
+            val clientStatusValidity: Duration = it.payload.clientStatus.expiresAt - now
+            assertTrue(clientStatusValidity > preferredClientStatusPeriod)
+            assertTrue(clientStatusValidity <= config.walletInstanceAttestation.clientStatusValidity.value)
+        }
+    }
+
+    @Test
+    fun `wallet instance attestation uses preferred client status validity when preference is more than configured`(
+        httpClient: HttpClient,
+        clock: Clock,
+        config: WalletProviderConfiguration,
+    ) {
+        val preferredClientStatusPeriod = config.walletInstanceAttestation.clientStatusValidity.value + 5.days
+
+        httpClient.runWalletInstanceAttestationTestCase(preferredClientStatusPeriod = preferredClientStatusPeriod) {
+            val now = clock.now()
+            val clientStatusValidity: Duration = it.payload.clientStatus.expiresAt - now
+            assertTrue(clientStatusValidity <= preferredClientStatusPeriod)
+            assertTrue(clientStatusValidity > config.walletInstanceAttestation.clientStatusValidity.value)
         }
     }
 }
 
 private fun HttpClient.runWalletInstanceAttestationTestCase(
-    walletMetadata: WalletMetadata?,
+    walletMetadata: WalletMetadata? = null,
+    preferredClientStatusPeriod: SecondsDuration? = null,
     assertions: suspend (WalletInstanceAttestation) -> Unit,
 ): TestResult =
     runTestWithRealTime {
@@ -94,6 +143,7 @@ private fun HttpClient.runWalletInstanceAttestationTestCase(
                         }
                     }.getOrThrow().publicKey.toJsonWebKey(),
                 walletMetadata = walletMetadata,
+                preferredClientStatusPeriod = preferredClientStatusPeriod,
             )
 
         val response =

--- a/wallet-provider-service/src/test/kotlin/WalletProviderTest.kt
+++ b/wallet-provider-service/src/test/kotlin/WalletProviderTest.kt
@@ -24,7 +24,6 @@ import arrow.fx.coroutines.ExitCase
 import com.sksamuel.hoplite.Secret
 import eu.europa.ec.eudi.walletprovider.adapter.persistence.challenge.Challenges
 import eu.europa.ec.eudi.walletprovider.config.*
-import eu.europa.ec.eudi.walletprovider.domain.NonBlankString
 import eu.europa.ec.eudi.walletprovider.domain.OpenId4VCISpec
 import eu.europa.ec.eudi.walletprovider.domain.time.Clock
 import eu.europa.ec.eudi.walletprovider.domain.toNonBlankString
@@ -82,56 +81,57 @@ private class WalletProviderExtension :
             prettyPrint = true
         }
 
-    private val testApplication: TestApplication =
-        run {
-            val config =
-                WalletProviderConfiguration(
-                    database =
-                        DatabaseConfiguration(
-                            url = database.r2dbcUrl.toNonBlankString(),
-                            username = database.username,
-                            password = Secret(database.password),
+    private val config =
+        WalletProviderConfiguration(
+            database =
+                DatabaseConfiguration(
+                    url = database.r2dbcUrl.toNonBlankString(),
+                    username = database.username,
+                    password = Secret(database.password),
+                ),
+            signingKey =
+                SigningKeyConfiguration(
+                    keystoreFile = Path.of("src/test/resources/keystore.jks"),
+                    keystorePassword = Secret("testKeystore"),
+                    keyAlias = "test-key".toNonBlankString(),
+                    keyPassword = Secret("testKeystore"),
+                    algorithm = SigningAlgorithm.ES256,
+                ),
+            walletInformation =
+                WalletInformationConfiguration(
+                    GeneralInformationConfiguration(
+                        provider = WalletProviderName("Wallet Provider"),
+                        id = SolutionId("EUDI Wallet"),
+                        version = SolutionVersion("1.0.0"),
+                        certification = CertificationInformation(JsonPrimitive("ARF")),
+                    ),
+                    WalletSecureCryptographicDeviceInformationConfiguration(
+                        WalletSecureCryptographicDeviceType.LocalNative,
+                        CertificationInformation(JsonPrimitive("ARF")),
+                    ),
+                ),
+            walletInstanceAttestation =
+                WalletInstanceAttestationConfiguration(
+                    walletName = "EUDI Wallet".toNonBlankString(),
+                    walletVersion = "1.0.0".toNonBlankString(),
+                    walletCertificationInformation =
+                        CertificationInformation(
+                            JsonPrimitive("https://github.com/eu-digital-identity-wallet"),
                         ),
-                    signingKey =
-                        SigningKeyConfiguration(
-                            keystoreFile = Path.of("src/test/resources/keystore.jks"),
-                            keystorePassword = Secret("testKeystore"),
-                            keyAlias = "test-key".toNonBlankString(),
-                            keyPassword = Secret("testKeystore"),
-                            algorithm = SigningAlgorithm.ES256,
-                        ),
-                    walletInformation =
-                        WalletInformationConfiguration(
-                            GeneralInformationConfiguration(
-                                provider = WalletProviderName("Wallet Provider"),
-                                id = SolutionId("EUDI Wallet"),
-                                version = SolutionVersion("1.0.0"),
-                                certification = CertificationInformation(JsonPrimitive("ARF")),
-                            ),
-                            WalletSecureCryptographicDeviceInformationConfiguration(
-                                WalletSecureCryptographicDeviceType.LocalNative,
-                                CertificationInformation(JsonPrimitive("ARF")),
-                            ),
-                        ),
-                    walletInstanceAttestation =
-                        WalletInstanceAttestationConfiguration(
-                            walletName = "EUDI Wallet".toNonBlankString(),
-                            walletVersion = "1.0.0".toNonBlankString(),
-                            walletCertificationInformation =
-                                CertificationInformation(
-                                    JsonPrimitive("https://github.com/eu-digital-identity-wallet"),
-                                ),
-                        ),
-                    tokenStatusListService =
-                        TokenStatusListServiceConfiguration(
-                            serviceUrl = URI.create("https://status.example.com/create").toURL(),
-                            apiKey = Secret("API-KEY"),
-                        ),
-                )
+                ),
+            tokenStatusListService =
+                TokenStatusListServiceConfiguration(
+                    serviceUrl = URI.create("https://status.example.com/create").toURL(),
+                    apiKey = Secret("API-KEY"),
+                ),
+        )
 
-            val clock = Clock.System
-            val database = runBlocking { context(resources) { config.database.connect() } }
-            val (signer, certificateChain) = runBlocking { config.signingKey.load() }
+    private val clock = Clock.System
+
+    private val testApplication: TestApplication =
+        runBlocking {
+            val database = context(resources) { config.database.connect() }
+            val (signer, certificateChain) = config.signingKey.load()
             val httpClient = context(resources) { createMockHttpClient(config, json) }
 
             TestApplication {
@@ -190,7 +190,9 @@ private class WalletProviderExtension :
         extensionContext: ExtensionContext,
     ): Boolean =
         arrow.fx.coroutines.ResourceScope::class.java.isAssignableFrom(parameterContext.parameter.type) ||
-            HttpClient::class.java.isAssignableFrom(parameterContext.parameter.type)
+            HttpClient::class.java.isAssignableFrom(parameterContext.parameter.type) ||
+            WalletProviderConfiguration::class.java.isAssignableFrom(parameterContext.parameter.type) ||
+            Clock::class.java.isAssignableFrom(parameterContext.parameter.type)
 
     override fun resolveParameter(
         parameterContext: ParameterContext,
@@ -199,6 +201,8 @@ private class WalletProviderExtension :
         when {
             arrow.fx.coroutines.ResourceScope::class.java.isAssignableFrom(parameterContext.parameter.type) -> resources
             HttpClient::class.java.isAssignableFrom(parameterContext.parameter.type) -> httpClient
+            WalletProviderConfiguration::class.java.isAssignableFrom(parameterContext.parameter.type) -> config
+            Clock::class.java.isAssignableFrom(parameterContext.parameter.type) -> clock
             else -> throw ParameterResolutionException("Unsupported parameter type: ${parameterContext.parameter.type}")
         }
 }


### PR DESCRIPTION
This PR add a new property to `WalletInstanceAttestationIssuanceRequest` called `preferredClientStatusPeriod`.

This property can be used by Wallets to communicate `preferred_client_status_period` during WIA issuance.

During WIA issuance Wallet Provider selects the Client Status validity period as `maxOf(preferredClientStatusPeriod, configuredClientStatusValidity)`. As such if a Wallet provides `preferredClientStatusPeriod` less than `configuredClientStatusValidity`, it is ignored.

Closes #72 