### PR TITLE
Rename Key Attestation -> Platform Key Attestation

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ By default, Wallet Provider performs no validation of platform Key Attestations.
 
 To enable platform Key Attestation validation, use the following environment variables:
 
-#### Android Key Attestation
+#### Android Platform Key Attestation
 
 Variable: `PLATFORMKEYATTESTATIONVALIDATION_ANDROID_ENABLED`   
 Description: Whether Android platform Key Attestations are enabled or not.  
@@ -327,29 +327,29 @@ Description: Tolerance added to the verification date.
 Default value: `0 seconds`  
 
 Variable: `PLATFORMKEYATTESTATIONVALIDATION_ANDROID_HARDWAREATTESTATIONENABLED`  
-Description: Whether **hardware** Key Attestations are accepted.  
+Description: Whether **hardware** platform Key Attestations are accepted.  
 Default value: `true`  
 
 Variable: `PLATFORMKEYATTESTATIONVALIDATION_ANDROID_SOFTWAREATTESTATIONENABLED`  
-Description: Whether **software** Key Attestations are accepted.  
+Description: Whether **software** platform Key Attestations are accepted.  
 Default value: `false`  
 
 Variable: `PLATFORMKEYATTESTATIONVALIDATION_ANDROID_SUPREMEPARSERENABLED`  
 Description: Whether to enable the Android platform Key Attestation parser provided by Warden Supreme.  
 Default value: `false`
 
-**Validity of Key Attestation**
+**Validity of platform Key Attestation**
 
-By default, Wallet Provider validates the creation time of the Key Attestation using a default skew of `5 minutes`. You can modify the `skew` using
+By default, Wallet Provider validates the creation time of the platform Key Attestation using a default skew of `5 minutes`. You can modify the `skew` using
 the following environment variable:
 
 Variable: `PLATFORMKEYATTESTATIONVALIDATION_ANDROID_ATTESTATIONSTATEMENTVALIDITY_SKEW`  
-Description: How far in the past, the creation date of a Key Attestation can be.  
+Description: How far in the past, the creation date of a platform Key Attestation can be.  
 Default value: `5 minutes`  
 
 To disable this check, set the environment variable `PLATFORMKEYATTESTATIONVALIDATION_ANDROID_ATTESTATIONSTATEMENTVALIDITY` to `Disabled`.
 
-##### iOS Key Attestation
+##### iOS Platform Key Attestation
 
 Variable: `PLATFORMKEYATTESTATIONVALIDATION_IOS_ENABLED`   
 Description: Whether iOS platform Key Attestations are enabled or not.  
@@ -371,7 +371,7 @@ Allowed values:
 * `Sandbox`
 
 Variable: `PLATFORMKEYATTESTATIONVALIDATION_IOS_ATTESTATIONSTATEMENTVALIDITY_SKEW`  
-Description: How far in the past, the creation date of a Key Attestation can be.  
+Description: How far in the past, the creation date of a platform Key Attestation can be.  
 Default value: `5 minutes`  
 
 ### Challenge Configuration

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -347,7 +347,7 @@
       "AndroidPlatformKeyAttestationWalletInstanceAttestationIssuanceRequest": {
         "type": "object",
         "properties": {
-          "keyAttestation": {
+          "platformKeyAttestation": {
             "$ref": "#/components/schemas/AndroidKeystoreAttestation"
           },
           "challenge": {
@@ -382,7 +382,7 @@
           }
         },
         "required": [
-          "keyAttestation",
+          "platformKeyAttestation",
           "challenge"
         ],
         "additionalProperties": false
@@ -408,7 +408,7 @@
       "IosPlatformKeyAttestationWalletInstanceAttestationIssuanceRequest": {
         "type": "object",
         "properties": {
-          "keyAttestation": {
+          "platformKeyAttestation": {
             "$ref": "#/components/schemas/IosHomebrewAttestation"
           },
           "challenge": {
@@ -443,7 +443,7 @@
           }
         },
         "required": [
-          "keyAttestation",
+          "platformKeyAttestation",
           "challenge"
         ],
         "additionalProperties": false
@@ -508,10 +508,10 @@
         "enum": [
           "unsupported_signing_algorithms",
           "invalid_challenge",
-          "invalid_key_attestation",
-          "unsupported_attested_key",
-          "unsupported_attested_key_type",
-          "unsupported_attested_key_curve",
+          "invalid_platform_key_attestation",
+          "unsupported_platform_attested_key",
+          "unsupported_platform_attested_key_type",
+          "unsupported_platform_attested_key_curve",
           "status_list_token_generation_failure"
         ]
       },
@@ -536,7 +536,7 @@
           "nonce": {
             "$ref": "#/components/schemas/Nonce"
           },
-          "keyAttestations": {
+          "platformKeyAttestations": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/AndroidKeystoreAttestation"
@@ -559,7 +559,7 @@
           }
         },
         "required": [
-          "keyAttestations",
+          "platformKeyAttestations",
           "challenge"
         ],
         "additionalProperties": false
@@ -582,10 +582,10 @@
           "unsupported_signing_algorithms",
           "invalid_preferred_ttl",
           "invalid_challenge",
-          "invalid_key_attestation",
-          "unsupported_attested_key",
-          "no_attested_keys",
-          "non_unique_attested_keys",
+          "invalid_platform_key_attestation",
+          "unsupported_platform_attested_key",
+          "no_platform_attested_keys",
+          "non_unique_platform_attested_keys",
           "status_list_token_generation_failure",
         ]
       },
@@ -612,7 +612,7 @@
           "nonce": {
             "$ref": "#/components/schemas/Nonce"
           },
-          "keyAttestations": {
+          "platformKeyAttestations": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/IosHomebrewAttestation"
@@ -635,7 +635,7 @@
           }
         },
         "required": [
-          "keyAttestations",
+          "platformKeyAttestations",
           "challenge"
         ],
         "additionalProperties": false

--- a/wallet-provider-service/src/main/kotlin/adapter/keyattestation/MakotoValidatePlatformKeyAttestation.kt
+++ b/wallet-provider-service/src/main/kotlin/adapter/keyattestation/MakotoValidatePlatformKeyAttestation.kt
@@ -21,19 +21,19 @@ import at.asitplus.attestation.AttestationResult
 import at.asitplus.attestation.Makoto
 import at.asitplus.signum.indispensable.Attestation
 import at.asitplus.signum.indispensable.toCryptoPublicKey
-import eu.europa.ec.eudi.walletprovider.domain.keyattestation.AttestedKey
+import eu.europa.ec.eudi.walletprovider.domain.platformkeyattestation.PlatformAttestedKey
 import eu.europa.ec.eudi.walletprovider.domain.toNonBlankString
-import eu.europa.ec.eudi.walletprovider.port.output.keyattestation.KeyAttestationValidationFailure
-import eu.europa.ec.eudi.walletprovider.port.output.keyattestation.ValidateKeyAttestation
+import eu.europa.ec.eudi.walletprovider.port.output.platformkeyattestation.PlatformKeyAttestationValidationFailure
+import eu.europa.ec.eudi.walletprovider.port.output.platformkeyattestation.ValidatePlatformKeyAttestation
 import at.asitplus.attestation.AttestationService as MakotoAttestationService
 
-class MakotoValidateKeyAttestation(
+class MakotoValidatePlatformKeyAttestation(
     private val makotoAttestationService: MakotoAttestationService,
-) : ValidateKeyAttestation {
+) : ValidatePlatformKeyAttestation {
     override suspend fun invoke(
         unvalidatedKeyAttestation: Attestation,
         challenge: ByteArray,
-    ): Either<KeyAttestationValidationFailure, AttestedKey> =
+    ): Either<PlatformKeyAttestationValidationFailure, PlatformAttestedKey> =
         either {
             val verificationResult = makotoAttestationService.verifyKeyAttestation(unvalidatedKeyAttestation, challenge)
 
@@ -49,8 +49,8 @@ class MakotoValidateKeyAttestation(
                             }
                     }.toNonBlankString()
                 raise(
-                    KeyAttestationValidationFailure
-                        .InvalidKeyAttestation(
+                    PlatformKeyAttestationValidationFailure
+                        .InvalidPlatformKeyAttestation(
                             error,
                             errorDetails.cause,
                         ),
@@ -63,14 +63,14 @@ class MakotoValidateKeyAttestation(
                     .toCryptoPublicKey()
                     .getOrElse {
                         raise(
-                            KeyAttestationValidationFailure.UnsupportedAttestedKey(
+                            PlatformKeyAttestationValidationFailure.UnsupportedPlatformAttestedKey(
                                 "Attested PublicKey is not supported".toNonBlankString(),
                                 it,
                             ),
                         )
                     }
 
-            AttestedKey(cryptoPublicKey, verificationResult.details)
+            PlatformAttestedKey(cryptoPublicKey, verificationResult.details)
         }
 }
 

--- a/wallet-provider-service/src/main/kotlin/adapter/platformkeyattestation/MakotoValidatePlatformKeyAttestation.kt
+++ b/wallet-provider-service/src/main/kotlin/adapter/platformkeyattestation/MakotoValidatePlatformKeyAttestation.kt
@@ -18,7 +18,6 @@ package eu.europa.ec.eudi.walletprovider.adapter.platformkeyattestation
 import arrow.core.Either
 import arrow.core.raise.either
 import at.asitplus.attestation.AttestationResult
-import at.asitplus.attestation.Makoto
 import at.asitplus.signum.indispensable.Attestation
 import at.asitplus.signum.indispensable.toCryptoPublicKey
 import eu.europa.ec.eudi.walletprovider.domain.platformkeyattestation.PlatformAttestedKey
@@ -39,15 +38,7 @@ class MakotoValidatePlatformKeyAttestation(
 
             if (!verificationResult.isSuccess) {
                 val errorDetails = verificationResult.details as AttestationResult.Error
-                val error =
-                    buildString {
-                        append(errorDetails.explanation)
-                        makotoAttestationService
-                            .debugInfo(unvalidatedKeyAttestation, challenge)
-                            ?.let {
-                                append("; $it")
-                            }
-                    }.toNonBlankString()
+                val error = errorDetails.explanation.toNonBlankString()
                 raise(
                     PlatformKeyAttestationValidationFailure
                         .InvalidPlatformKeyAttestation(
@@ -73,12 +64,3 @@ class MakotoValidatePlatformKeyAttestation(
             PlatformAttestedKey(cryptoPublicKey, verificationResult.details)
         }
 }
-
-private fun MakotoAttestationService.debugInfo(
-    unvalidatedKeyAttestation: Attestation,
-    challenge: ByteArray,
-): String? =
-    if (this !is Makoto)
-        null
-    else
-        collectDebugInfo(unvalidatedKeyAttestation, challenge).serializeCompact()

--- a/wallet-provider-service/src/main/kotlin/adapter/platformkeyattestation/MakotoValidatePlatformKeyAttestation.kt
+++ b/wallet-provider-service/src/main/kotlin/adapter/platformkeyattestation/MakotoValidatePlatformKeyAttestation.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package eu.europa.ec.eudi.walletprovider.adapter.keyattestation
+package eu.europa.ec.eudi.walletprovider.adapter.platformkeyattestation
 
 import arrow.core.Either
 import arrow.core.raise.either

--- a/wallet-provider-service/src/main/kotlin/config/WalletInstanceAttestationRoutes.kt
+++ b/wallet-provider-service/src/main/kotlin/config/WalletInstanceAttestationRoutes.kt
@@ -19,7 +19,7 @@ import eu.europa.ec.eudi.walletprovider.domain.walletinstanceattestation.WalletI
 import eu.europa.ec.eudi.walletprovider.port.input.walletinstanceattestation.IssueWalletInstanceAttestation
 import eu.europa.ec.eudi.walletprovider.port.input.walletinstanceattestation.WalletInstanceAttestationIssuanceFailure
 import eu.europa.ec.eudi.walletprovider.port.input.walletinstanceattestation.WalletInstanceAttestationIssuanceRequest
-import eu.europa.ec.eudi.walletprovider.port.output.keyattestation.KeyAttestationValidationFailure
+import eu.europa.ec.eudi.walletprovider.port.output.platformkeyattestation.PlatformKeyAttestationValidationFailure
 import eu.europa.ec.eudi.walletprovider.port.output.tokenstatuslist.StatusListTokenGenerationFailure
 import io.ktor.http.*
 import io.ktor.server.application.*
@@ -92,31 +92,31 @@ private fun Logger.warn(failure: WalletInstanceAttestationIssuanceFailure) {
                     failure.cause
             }
 
-            is WalletInstanceAttestationIssuanceFailure.InvalidKeyAttestation -> {
-                when (val keyAttestationFailure = failure.error) {
-                    is KeyAttestationValidationFailure.InvalidKeyAttestation -> {
+            is WalletInstanceAttestationIssuanceFailure.InvalidPlatformKeyAttestation -> {
+                when (val platformKeyAttestationFailure = failure.error) {
+                    is PlatformKeyAttestationValidationFailure.InvalidPlatformKeyAttestation -> {
                         "WalletInstanceAttestationIssuanceRequest validation failed, " +
-                            "Key Attestation is not valid: ${keyAttestationFailure.error}" to
-                            keyAttestationFailure.cause
+                            "Platform Key Attestation is not valid: ${platformKeyAttestationFailure.error}" to
+                            platformKeyAttestationFailure.cause
                     }
 
-                    is KeyAttestationValidationFailure.UnsupportedAttestedKey -> {
+                    is PlatformKeyAttestationValidationFailure.UnsupportedPlatformAttestedKey -> {
                         "WalletInstanceAttestationIssuanceRequest validation failed, " +
-                            "Key Attestation contains an unsupported PublicKey: ${keyAttestationFailure.error}" to
-                            keyAttestationFailure.cause
+                            "Platform Key Attestation contains an unsupported PublicKey: ${platformKeyAttestationFailure.error}" to
+                            platformKeyAttestationFailure.cause
                     }
                 }
             }
 
-            is WalletInstanceAttestationIssuanceFailure.UnsupportedAttestedKeyType -> {
+            is WalletInstanceAttestationIssuanceFailure.UnsupportedPlatformAttestedKeyType -> {
                 "WalletInstanceAttestationIssuanceRequest validation failed, " +
-                    "Attested Key Type is not supported: ${failure.type.name}" to
+                    "Platform Attested Key Type is not supported: ${failure.type.name}" to
                     null
             }
 
-            is WalletInstanceAttestationIssuanceFailure.UnsupportedAttestedKeyCurve -> {
+            is WalletInstanceAttestationIssuanceFailure.UnsupportedPlatformAttestedKeyCurve -> {
                 "WalletInstanceAttestationIssuanceRequest validation failed, " +
-                    "Attested Key Curve is not supported: ${failure.curve.name}" to
+                    "Platform Attested Key Curve is not supported: ${failure.curve.name}" to
                     null
             }
 
@@ -151,17 +151,17 @@ private enum class WalletInstanceAttestationError {
     @SerialName("invalid_challenge")
     InvalidChallenge,
 
-    @SerialName("invalid_key_attestation")
-    InvalidKeyAttestation,
+    @SerialName("invalid_platform_key_attestation")
+    InvalidPlatformKeyAttestation,
 
-    @SerialName("unsupported_attested_key")
-    UnsupportedAttestedKey,
+    @SerialName("unsupported_platform_attested_key")
+    UnsupportedPlatformAttestedKey,
 
-    @SerialName("unsupported_attested_key_type")
-    UnsupportedAttestedKeyType,
+    @SerialName("unsupported_platform_attested_key_type")
+    UnsupportedPlatformAttestedKeyType,
 
-    @SerialName("unsupported_attested_key_curve")
-    UnsupportedAttestedKeyCurve,
+    @SerialName("unsupported_platform_attested_key_curve")
+    UnsupportedPlatformAttestedKeyCurve,
 
     @SerialName("status_list_token_generation_failure")
     StatusListTokenGenerationFailure,
@@ -182,19 +182,24 @@ private fun WalletInstanceAttestationIssuanceFailure.toWalletInstanceAttestation
             WalletInstanceAttestationError.InvalidChallenge
         }
 
-        is WalletInstanceAttestationIssuanceFailure.InvalidKeyAttestation -> {
+        is WalletInstanceAttestationIssuanceFailure.InvalidPlatformKeyAttestation -> {
             when (error) {
-                is KeyAttestationValidationFailure.InvalidKeyAttestation -> WalletInstanceAttestationError.InvalidKeyAttestation
-                is KeyAttestationValidationFailure.UnsupportedAttestedKey -> WalletInstanceAttestationError.UnsupportedAttestedKey
+                is PlatformKeyAttestationValidationFailure.InvalidPlatformKeyAttestation -> {
+                    WalletInstanceAttestationError.InvalidPlatformKeyAttestation
+                }
+
+                is PlatformKeyAttestationValidationFailure.UnsupportedPlatformAttestedKey -> {
+                    WalletInstanceAttestationError.UnsupportedPlatformAttestedKey
+                }
             }
         }
 
-        is WalletInstanceAttestationIssuanceFailure.UnsupportedAttestedKeyType -> {
-            WalletInstanceAttestationError.UnsupportedAttestedKeyType
+        is WalletInstanceAttestationIssuanceFailure.UnsupportedPlatformAttestedKeyType -> {
+            WalletInstanceAttestationError.UnsupportedPlatformAttestedKeyType
         }
 
-        is WalletInstanceAttestationIssuanceFailure.UnsupportedAttestedKeyCurve -> {
-            WalletInstanceAttestationError.UnsupportedAttestedKeyCurve
+        is WalletInstanceAttestationIssuanceFailure.UnsupportedPlatformAttestedKeyCurve -> {
+            WalletInstanceAttestationError.UnsupportedPlatformAttestedKeyCurve
         }
 
         is WalletInstanceAttestationIssuanceFailure.StatusListTokenGenerationFailure -> {

--- a/wallet-provider-service/src/main/kotlin/config/WalletProviderModuleConfiguration.kt
+++ b/wallet-provider-service/src/main/kotlin/config/WalletProviderModuleConfiguration.kt
@@ -22,9 +22,9 @@ import at.asitplus.attestation.android.AndroidAttestationConfiguration
 import at.asitplus.signum.indispensable.pki.CertificateChain
 import at.asitplus.signum.supreme.sign.Signer
 import eu.europa.ec.eudi.walletprovider.adapter.jose.SignumSignJwt
-import eu.europa.ec.eudi.walletprovider.adapter.keyattestation.MakotoValidatePlatformKeyAttestation
 import eu.europa.ec.eudi.walletprovider.adapter.persistence.RunInTransactionLive
 import eu.europa.ec.eudi.walletprovider.adapter.persistence.challenge.ChallengeRepositoryLive
+import eu.europa.ec.eudi.walletprovider.adapter.platformkeyattestation.MakotoValidatePlatformKeyAttestation
 import eu.europa.ec.eudi.walletprovider.adapter.tokenstatuslist.ApiKey
 import eu.europa.ec.eudi.walletprovider.adapter.tokenstatuslist.TokenStatusListServiceGenerateStatusListToken
 import eu.europa.ec.eudi.walletprovider.config.IosKeyAttestationConfiguration.ApplicationConfiguration.IosEnvironment

--- a/wallet-provider-service/src/main/kotlin/config/WalletProviderModuleConfiguration.kt
+++ b/wallet-provider-service/src/main/kotlin/config/WalletProviderModuleConfiguration.kt
@@ -22,7 +22,7 @@ import at.asitplus.attestation.android.AndroidAttestationConfiguration
 import at.asitplus.signum.indispensable.pki.CertificateChain
 import at.asitplus.signum.supreme.sign.Signer
 import eu.europa.ec.eudi.walletprovider.adapter.jose.SignumSignJwt
-import eu.europa.ec.eudi.walletprovider.adapter.keyattestation.MakotoValidateKeyAttestation
+import eu.europa.ec.eudi.walletprovider.adapter.keyattestation.MakotoValidatePlatformKeyAttestation
 import eu.europa.ec.eudi.walletprovider.adapter.persistence.RunInTransactionLive
 import eu.europa.ec.eudi.walletprovider.adapter.persistence.challenge.ChallengeRepositoryLive
 import eu.europa.ec.eudi.walletprovider.adapter.tokenstatuslist.ApiKey
@@ -98,7 +98,7 @@ fun Application.configureWalletProviderModule(
         }
 
     val makotoAttestationService = createMakotoAttestationService(config, clock)
-    val validateKeyAttestation = MakotoValidateKeyAttestation(makotoAttestationService)
+    val validatePlatformKeyAttestation = MakotoValidatePlatformKeyAttestation(makotoAttestationService)
 
     val generateStatusListToken =
         TokenStatusListServiceGenerateStatusListToken(
@@ -112,7 +112,7 @@ fun Application.configureWalletProviderModule(
         IssueWalletInstanceAttestationLive(
             clock,
             validateChallenge,
-            validateKeyAttestation,
+            validatePlatformKeyAttestation,
             config.walletInstanceAttestation.validity,
             issuer = config.issuer.publicUrl,
             clientId = config.clientId,
@@ -134,7 +134,7 @@ fun Application.configureWalletProviderModule(
         IssueWalletUnitAttestationLive(
             clock = clock,
             validateChallenge = validateChallenge,
-            validateKeyAttestation = validateKeyAttestation,
+            validatePlatformKeyAttestation = validatePlatformKeyAttestation,
             validity = WalletUnitAttestationValidity(config.walletUnitAttestation.validity.closedRange),
             generateStatusListToken = generateStatusListToken,
             certification = config.walletUnitAttestation.certification,

--- a/wallet-provider-service/src/main/kotlin/config/WalletUnitAttestationRoutes.kt
+++ b/wallet-provider-service/src/main/kotlin/config/WalletUnitAttestationRoutes.kt
@@ -22,7 +22,7 @@ import eu.europa.ec.eudi.walletprovider.domain.walletunitattestation.WalletUnitA
 import eu.europa.ec.eudi.walletprovider.port.input.walletunitattestation.IssueWalletUnitAttestation
 import eu.europa.ec.eudi.walletprovider.port.input.walletunitattestation.WalletUnitAttestationIssuanceFailure
 import eu.europa.ec.eudi.walletprovider.port.input.walletunitattestation.WalletUnitAttestationIssuanceRequest
-import eu.europa.ec.eudi.walletprovider.port.output.keyattestation.KeyAttestationValidationFailure
+import eu.europa.ec.eudi.walletprovider.port.output.platformkeyattestation.PlatformKeyAttestationValidationFailure
 import eu.europa.ec.eudi.walletprovider.port.output.tokenstatuslist.StatusListTokenGenerationFailure
 import io.ktor.http.*
 import io.ktor.server.application.*
@@ -102,19 +102,19 @@ private fun Logger.warn(failure: WalletUnitAttestationIssuanceFailure) {
             )
         }
 
-        is WalletUnitAttestationIssuanceFailure.InvalidKeyAttestations -> {
+        is WalletUnitAttestationIssuanceFailure.InvalidPlatformKeyAttestations -> {
             failure.errors.forEach {
                 when (it) {
-                    is KeyAttestationValidationFailure.InvalidKeyAttestation -> {
+                    is PlatformKeyAttestationValidationFailure.InvalidPlatformKeyAttestation -> {
                         warn(
-                            "WalletUnitAttestationIssuanceRequest validation failed, Key Attestation is not valid: ${it.error}",
+                            "WalletUnitAttestationIssuanceRequest validation failed, Platform Key Attestation is not valid: ${it.error}",
                             it.cause,
                         )
                     }
 
-                    is KeyAttestationValidationFailure.UnsupportedAttestedKey -> {
+                    is PlatformKeyAttestationValidationFailure.UnsupportedPlatformAttestedKey -> {
                         warn(
-                            "WalletUnitAttestationIssuanceRequest validation failed, Key Attestation contains an unsupported PublicKey: ${it.error}",
+                            "WalletUnitAttestationIssuanceRequest validation failed, Platform Key Attestation contains an unsupported PublicKey: ${it.error}",
                             it.cause,
                         )
                     }
@@ -122,12 +122,12 @@ private fun Logger.warn(failure: WalletUnitAttestationIssuanceFailure) {
             }
         }
 
-        WalletUnitAttestationIssuanceFailure.NoAttestedKeys -> {
-            warn("WalletUnitAttestationIssuanceRequest validation failed, contains no Attested Keys")
+        WalletUnitAttestationIssuanceFailure.NoPlatformAttestedKeys -> {
+            warn("WalletUnitAttestationIssuanceRequest validation failed, contains no Platform Attested Keys")
         }
 
-        WalletUnitAttestationIssuanceFailure.NonUniqueAttestedKeys -> {
-            warn("WalletUnitAttestationIssuanceRequest validation failed, contains non-unique Attested Keys")
+        WalletUnitAttestationIssuanceFailure.NonUniquePlatformAttestedKeys -> {
+            warn("WalletUnitAttestationIssuanceRequest validation failed, contains non-unique Platform Attested Keys")
         }
 
         is WalletUnitAttestationIssuanceFailure.StatusListTokenGenerationFailure -> {
@@ -160,17 +160,17 @@ private enum class WalletUnitAttestationError {
     @SerialName("invalid_challenge")
     InvalidChallenge,
 
-    @SerialName("invalid_key_attestation")
-    InvalidKeyAttestation,
+    @SerialName("invalid_platform_key_attestation")
+    InvalidPlatformKeyAttestation,
 
-    @SerialName("unsupported_attested_key")
-    UnsupportedAttestedKey,
+    @SerialName("unsupported_platform_attested_key")
+    UnsupportedPlatformAttestedKey,
 
-    @SerialName("no_attested_keys")
-    NoAttestedKeys,
+    @SerialName("no_platform_attested_keys")
+    NoPlatformAttestedKeys,
 
-    @SerialName("non_unique_attested_keys")
-    NonUniqueAttestedKeys,
+    @SerialName("non_unique_platform_attested_keys")
+    NonUniquePlatformAttestedKeys,
 
     @SerialName("status_list_token_generation_failure")
     StatusListTokenGenerationFailure,
@@ -195,22 +195,27 @@ private fun WalletUnitAttestationIssuanceFailure.toWalletUnitAttestationErrorRes
             nonEmptyListOf(WalletUnitAttestationError.InvalidChallenge)
         }
 
-        is WalletUnitAttestationIssuanceFailure.InvalidKeyAttestations -> {
+        is WalletUnitAttestationIssuanceFailure.InvalidPlatformKeyAttestations -> {
             errors
                 .map {
                     when (it) {
-                        is KeyAttestationValidationFailure.InvalidKeyAttestation -> WalletUnitAttestationError.InvalidKeyAttestation
-                        is KeyAttestationValidationFailure.UnsupportedAttestedKey -> WalletUnitAttestationError.UnsupportedAttestedKey
+                        is PlatformKeyAttestationValidationFailure.InvalidPlatformKeyAttestation -> {
+                            WalletUnitAttestationError.InvalidPlatformKeyAttestation
+                        }
+
+                        is PlatformKeyAttestationValidationFailure.UnsupportedPlatformAttestedKey -> {
+                            WalletUnitAttestationError.UnsupportedPlatformAttestedKey
+                        }
                     }
                 }.distinct()
         }
 
-        WalletUnitAttestationIssuanceFailure.NoAttestedKeys -> {
-            nonEmptyListOf(WalletUnitAttestationError.NoAttestedKeys)
+        WalletUnitAttestationIssuanceFailure.NoPlatformAttestedKeys -> {
+            nonEmptyListOf(WalletUnitAttestationError.NoPlatformAttestedKeys)
         }
 
-        WalletUnitAttestationIssuanceFailure.NonUniqueAttestedKeys -> {
-            nonEmptyListOf(WalletUnitAttestationError.NonUniqueAttestedKeys)
+        WalletUnitAttestationIssuanceFailure.NonUniquePlatformAttestedKeys -> {
+            nonEmptyListOf(WalletUnitAttestationError.NonUniquePlatformAttestedKeys)
         }
 
         is WalletUnitAttestationIssuanceFailure.StatusListTokenGenerationFailure -> {

--- a/wallet-provider-service/src/main/kotlin/domain/platformkeyattestation/PlatformAttestedKey.kt
+++ b/wallet-provider-service/src/main/kotlin/domain/platformkeyattestation/PlatformAttestedKey.kt
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package eu.europa.ec.eudi.walletprovider.domain.keyattestation
+package eu.europa.ec.eudi.walletprovider.domain.platformkeyattestation
 
 import at.asitplus.attestation.AttestationResult
 import at.asitplus.signum.indispensable.CryptoPublicKey
 
-data class AttestedKey(
+data class PlatformAttestedKey(
     val publicKey: CryptoPublicKey,
     val attestationResult: AttestationResult,
 ) {

--- a/wallet-provider-service/src/main/kotlin/port/input/walletinstanceattestation/IssueWalletInstanceAttestation.kt
+++ b/wallet-provider-service/src/main/kotlin/port/input/walletinstanceattestation/IssueWalletInstanceAttestation.kt
@@ -31,8 +31,8 @@ import eu.europa.ec.eudi.walletprovider.domain.tokenstatuslist.Status
 import eu.europa.ec.eudi.walletprovider.domain.walletinstanceattestation.*
 import eu.europa.ec.eudi.walletprovider.port.output.challenge.ValidateChallenge
 import eu.europa.ec.eudi.walletprovider.port.output.jose.SignJwt
-import eu.europa.ec.eudi.walletprovider.port.output.keyattestation.KeyAttestationValidationFailure
-import eu.europa.ec.eudi.walletprovider.port.output.keyattestation.ValidateKeyAttestation
+import eu.europa.ec.eudi.walletprovider.port.output.platformkeyattestation.PlatformKeyAttestationValidationFailure
+import eu.europa.ec.eudi.walletprovider.port.output.platformkeyattestation.ValidatePlatformKeyAttestation
 import eu.europa.ec.eudi.walletprovider.port.output.tokenstatuslist.GenerateStatusListToken
 import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
@@ -50,13 +50,13 @@ sealed interface WalletInstanceAttestationIssuanceRequest {
     val walletMetadata: WalletMetadata?
     val preferredClientStatusPeriod: SecondsDuration?
 
-    sealed interface PlatformKeyAttestation<out KeyAttestation : Attestation> : WalletInstanceAttestationIssuanceRequest {
-        val keyAttestation: KeyAttestation
+    sealed interface PlatformKeyAttestation<out PlatformKeyAttestation : Attestation> : WalletInstanceAttestationIssuanceRequest {
+        val platformKeyAttestation: PlatformKeyAttestation
         val challenge: Base64UrlSafeByteArray
 
         @Serializable
         data class Android(
-            @Required override val keyAttestation: AndroidKeystoreAttestation,
+            @Required override val platformKeyAttestation: AndroidKeystoreAttestation,
             @Required override val challenge: Base64UrlSafeByteArray,
             @Serializable(
                 with = NonEmptyListSerializer::class,
@@ -66,14 +66,14 @@ sealed interface WalletInstanceAttestationIssuanceRequest {
         ) : PlatformKeyAttestation<AndroidKeystoreAttestation> {
             override fun equals(other: Any?): Boolean =
                 other is Android &&
-                    other.keyAttestation == keyAttestation &&
+                    other.platformKeyAttestation == platformKeyAttestation &&
                     other.challenge.contentEquals(challenge) &&
                     other.supportedSigningAlgorithms == supportedSigningAlgorithms &&
                     other.walletMetadata == walletMetadata &&
                     other.preferredClientStatusPeriod == preferredClientStatusPeriod
 
             override fun hashCode(): Int {
-                var result = keyAttestation.hashCode()
+                var result = platformKeyAttestation.hashCode()
                 result = 31 * result + challenge.contentHashCode()
                 result = 31 * result + (supportedSigningAlgorithms?.hashCode() ?: 0)
                 result = 31 * result + (walletMetadata?.hashCode() ?: 0)
@@ -84,7 +84,7 @@ sealed interface WalletInstanceAttestationIssuanceRequest {
 
         @Serializable
         data class Ios(
-            @Required override val keyAttestation: IosHomebrewAttestation,
+            @Required override val platformKeyAttestation: IosHomebrewAttestation,
             @Required override val challenge: Base64UrlSafeByteArray,
             @Serializable(
                 with = NonEmptyListSerializer::class,
@@ -94,14 +94,14 @@ sealed interface WalletInstanceAttestationIssuanceRequest {
         ) : PlatformKeyAttestation<IosHomebrewAttestation> {
             override fun equals(other: Any?): Boolean =
                 other is Ios &&
-                    other.keyAttestation == keyAttestation &&
+                    other.platformKeyAttestation == platformKeyAttestation &&
                     other.challenge.contentEquals(challenge) &&
                     other.supportedSigningAlgorithms == supportedSigningAlgorithms &&
                     other.walletMetadata == walletMetadata &&
                     other.preferredClientStatusPeriod == preferredClientStatusPeriod
 
             override fun hashCode(): Int {
-                var result = keyAttestation.hashCode()
+                var result = platformKeyAttestation.hashCode()
                 result = 31 * result + challenge.contentHashCode()
                 result = 31 * result + (supportedSigningAlgorithms?.hashCode() ?: 0)
                 result = 31 * result + (walletMetadata?.hashCode() ?: 0)
@@ -131,15 +131,15 @@ sealed interface WalletInstanceAttestationIssuanceFailure {
         val cause: Throwable? = null,
     ) : WalletInstanceAttestationIssuanceFailure
 
-    class InvalidKeyAttestation(
-        val error: KeyAttestationValidationFailure,
+    class InvalidPlatformKeyAttestation(
+        val error: PlatformKeyAttestationValidationFailure,
     ) : WalletInstanceAttestationIssuanceFailure
 
-    data class UnsupportedAttestedKeyType(
+    data class UnsupportedPlatformAttestedKeyType(
         val type: JwkType,
     ) : WalletInstanceAttestationIssuanceFailure
 
-    data class UnsupportedAttestedKeyCurve(
+    data class UnsupportedPlatformAttestedKeyCurve(
         val curve: ECCurve,
     ) : WalletInstanceAttestationIssuanceFailure
 
@@ -169,7 +169,7 @@ value class WalletInstanceAttestationValidity(
 class IssueWalletInstanceAttestationLive(
     private val clock: Clock,
     private val validateChallenge: ValidateChallenge,
-    private val validateKeyAttestation: ValidateKeyAttestation,
+    private val validatePlatformKeyAttestation: ValidatePlatformKeyAttestation,
     private val validity: WalletInstanceAttestationValidity,
     private val issuer: Issuer,
     private val clientId: ClientId,
@@ -196,15 +196,15 @@ class IssueWalletInstanceAttestationLive(
                 }
             }
 
-            val attestedKey =
+            val platformAttestedKey =
                 when (request) {
                     is WalletInstanceAttestationIssuanceRequest.PlatformKeyAttestation<*> -> {
                         validateChallenge(request.challenge, clock.now())
                             .mapLeft { WalletInstanceAttestationIssuanceFailure.InvalidChallenge(it.error, it.cause) }
                             .bind()
 
-                        validateKeyAttestation(request.keyAttestation, request.challenge)
-                            .mapLeft { WalletInstanceAttestationIssuanceFailure.InvalidKeyAttestation(it) }
+                        validatePlatformKeyAttestation(request.platformKeyAttestation, request.challenge)
+                            .mapLeft { WalletInstanceAttestationIssuanceFailure.InvalidPlatformKeyAttestation(it) }
                             .bind()
                             .publicKey
                             .toJsonWebKey()
@@ -215,14 +215,14 @@ class IssueWalletInstanceAttestationLive(
                     }
                 }
 
-            val attestedKeyType = checkNotNull(attestedKey.type) { "Attested Key is missing `kty` claim" }
-            ensure(JwkType.EC == attestedKeyType) {
-                WalletInstanceAttestationIssuanceFailure.UnsupportedAttestedKeyType(attestedKeyType)
+            val platformAttestedKeyType = checkNotNull(platformAttestedKey.type) { "Platform Attested Key is missing `kty` claim" }
+            ensure(JwkType.EC == platformAttestedKeyType) {
+                WalletInstanceAttestationIssuanceFailure.UnsupportedPlatformAttestedKeyType(platformAttestedKeyType)
             }
 
-            val attestedKeyCurve = checkNotNull(attestedKey.curve) { "Attested Key is missing `crv` claim" }
-            ensure(attestedKeyCurve in setOf(ECCurve.SECP_256_R_1, ECCurve.SECP_384_R_1, ECCurve.SECP_521_R_1)) {
-                WalletInstanceAttestationIssuanceFailure.UnsupportedAttestedKeyCurve(attestedKeyCurve)
+            val platformAttestedKeyCurve = checkNotNull(platformAttestedKey.curve) { "Platform Attested Key is missing `crv` claim" }
+            ensure(platformAttestedKeyCurve in setOf(ECCurve.SECP_256_R_1, ECCurve.SECP_384_R_1, ECCurve.SECP_521_R_1)) {
+                WalletInstanceAttestationIssuanceFailure.UnsupportedPlatformAttestedKeyCurve(platformAttestedKeyCurve)
             }
 
             val issuedAt = clock.now()
@@ -243,7 +243,7 @@ class IssueWalletInstanceAttestationLive(
                     issuer,
                     clientId,
                     expiresAt = expiresAt,
-                    ConfirmationClaim(jsonWebKey = attestedKey),
+                    ConfirmationClaim(jsonWebKey = platformAttestedKey),
                     issuedAt = issuedAt,
                     notBefore = issuedAt,
                     walletName = walletName,

--- a/wallet-provider-service/src/main/kotlin/port/input/walletunitattestation/IssueWalletUnitAttestation.kt
+++ b/wallet-provider-service/src/main/kotlin/port/input/walletunitattestation/IssueWalletUnitAttestation.kt
@@ -41,8 +41,8 @@ import eu.europa.ec.eudi.walletprovider.domain.walletunitattestation.WalletUnitA
 import eu.europa.ec.eudi.walletprovider.domain.walletunitattestation.WalletUnitAttestationClaims
 import eu.europa.ec.eudi.walletprovider.port.output.challenge.ValidateChallenge
 import eu.europa.ec.eudi.walletprovider.port.output.jose.SignJwt
-import eu.europa.ec.eudi.walletprovider.port.output.keyattestation.KeyAttestationValidationFailure
-import eu.europa.ec.eudi.walletprovider.port.output.keyattestation.ValidateKeyAttestation
+import eu.europa.ec.eudi.walletprovider.port.output.platformkeyattestation.PlatformKeyAttestationValidationFailure
+import eu.europa.ec.eudi.walletprovider.port.output.platformkeyattestation.ValidatePlatformKeyAttestation
 import eu.europa.ec.eudi.walletprovider.port.output.tokenstatuslist.GenerateStatusListToken
 import kotlinx.coroutines.Dispatchers
 import kotlinx.serialization.Required
@@ -61,15 +61,15 @@ sealed interface WalletUnitAttestationIssuanceRequest {
     val supportedSigningAlgorithms: NonEmptyList<JsonWebAlgorithm>?
     val preferredTtl: SecondsDuration?
 
-    sealed interface PlatformKeyAttestation<out KeyAttestation : Attestation> : WalletUnitAttestationIssuanceRequest {
-        val keyAttestations: NonEmptyList<KeyAttestation>
+    sealed interface PlatformKeyAttestation<out PlatformKeyAttestation : Attestation> : WalletUnitAttestationIssuanceRequest {
+        val platformKeyAttestations: NonEmptyList<PlatformKeyAttestation>
         val challenge: Base64UrlSafeByteArray
 
         @Serializable
         data class Android(
             override val nonce: Nonce? = null,
             @Required @Serializable(with = NonEmptyListSerializer::class)
-            override val keyAttestations: NonEmptyList<AndroidKeystoreAttestation>,
+            override val platformKeyAttestations: NonEmptyList<AndroidKeystoreAttestation>,
             @Required override val challenge: Base64UrlSafeByteArray,
             @Serializable(
                 with = NonEmptyListSerializer::class,
@@ -79,14 +79,14 @@ sealed interface WalletUnitAttestationIssuanceRequest {
             override fun equals(other: Any?): Boolean =
                 other is Android &&
                     other.nonce == nonce &&
-                    other.keyAttestations == keyAttestations &&
+                    other.platformKeyAttestations == platformKeyAttestations &&
                     other.challenge.contentEquals(challenge) &&
                     other.supportedSigningAlgorithms == supportedSigningAlgorithms &&
                     other.preferredTtl == preferredTtl
 
             override fun hashCode(): Int {
                 var result = nonce?.hashCode() ?: 0
-                result = 31 * result + keyAttestations.hashCode()
+                result = 31 * result + platformKeyAttestations.hashCode()
                 result = 31 * result + challenge.contentHashCode()
                 result = 31 * result + (supportedSigningAlgorithms?.hashCode() ?: 0)
                 result = 31 * result + (preferredTtl?.hashCode() ?: 0)
@@ -98,7 +98,7 @@ sealed interface WalletUnitAttestationIssuanceRequest {
         data class Ios(
             override val nonce: Nonce? = null,
             @Required @Serializable(with = NonEmptyListSerializer::class)
-            override val keyAttestations: NonEmptyList<IosHomebrewAttestation>,
+            override val platformKeyAttestations: NonEmptyList<IosHomebrewAttestation>,
             @Required override val challenge: Base64UrlSafeByteArray,
             @Serializable(
                 with = NonEmptyListSerializer::class,
@@ -108,14 +108,14 @@ sealed interface WalletUnitAttestationIssuanceRequest {
             override fun equals(other: Any?): Boolean =
                 other is Ios &&
                     other.nonce == nonce &&
-                    other.keyAttestations == keyAttestations &&
+                    other.platformKeyAttestations == platformKeyAttestations &&
                     other.challenge.contentEquals(challenge) &&
                     other.supportedSigningAlgorithms == supportedSigningAlgorithms &&
                     other.preferredTtl == preferredTtl
 
             override fun hashCode(): Int {
                 var result = nonce?.hashCode() ?: 0
-                result = 31 * result + keyAttestations.hashCode()
+                result = 31 * result + platformKeyAttestations.hashCode()
                 result = 31 * result + challenge.contentHashCode()
                 result = 31 * result + (supportedSigningAlgorithms?.hashCode() ?: 0)
                 result = 31 * result + (preferredTtl?.hashCode() ?: 0)
@@ -154,13 +154,13 @@ sealed interface WalletUnitAttestationIssuanceFailure {
         val cause: Throwable? = null,
     ) : WalletUnitAttestationIssuanceFailure
 
-    class InvalidKeyAttestations(
-        val errors: NonEmptyList<KeyAttestationValidationFailure>,
+    class InvalidPlatformKeyAttestations(
+        val errors: NonEmptyList<PlatformKeyAttestationValidationFailure>,
     ) : WalletUnitAttestationIssuanceFailure
 
-    data object NoAttestedKeys : WalletUnitAttestationIssuanceFailure
+    data object NoPlatformAttestedKeys : WalletUnitAttestationIssuanceFailure
 
-    data object NonUniqueAttestedKeys : WalletUnitAttestationIssuanceFailure
+    data object NonUniquePlatformAttestedKeys : WalletUnitAttestationIssuanceFailure
 
     class StatusListTokenGenerationFailure(
         val error: eu.europa.ec.eudi.walletprovider.port.output.tokenstatuslist.StatusListTokenGenerationFailure,
@@ -186,7 +186,7 @@ value class WalletUnitAttestationValidity(
 class IssueWalletUnitAttestationLive(
     private val clock: Clock,
     private val validateChallenge: ValidateChallenge,
-    private val validateKeyAttestation: ValidateKeyAttestation,
+    private val validatePlatformKeyAttestation: ValidatePlatformKeyAttestation,
     private val validity: WalletUnitAttestationValidity,
     private val generateStatusListToken: GenerateStatusListToken,
     private val certification: StringUrl,
@@ -204,16 +204,16 @@ class IssueWalletUnitAttestationLive(
                 }
             }
 
-            val attestedKeys =
+            val platformAttestedKeys =
                 when (request) {
                     is WalletUnitAttestationIssuanceRequest.PlatformKeyAttestation<*> -> {
                         validateChallenge(request.challenge, clock.now())
                             .mapLeft { WalletUnitAttestationIssuanceFailure.InvalidChallenge(it.error, it.cause) }
                             .bind()
 
-                        request.keyAttestations
-                            .parMapOrAccumulate(Dispatchers.Default, 4) { validateKeyAttestation(it, request.challenge).bind() }
-                            .mapLeft { errors -> WalletUnitAttestationIssuanceFailure.InvalidKeyAttestations(errors) }
+                        request.platformKeyAttestations
+                            .parMapOrAccumulate(Dispatchers.Default, 4) { validatePlatformKeyAttestation(it, request.challenge).bind() }
+                            .mapLeft { errors -> WalletUnitAttestationIssuanceFailure.InvalidPlatformKeyAttestations(errors) }
                             .bind()
                             .map { it.publicKey.toJsonWebKey() }
                             .toNonEmptyListOrNull()
@@ -224,8 +224,10 @@ class IssueWalletUnitAttestationLive(
                     }
                 }
 
-            ensureNotNull(attestedKeys) { WalletUnitAttestationIssuanceFailure.NoAttestedKeys }
-            ensure(attestedKeys.distinct().size == attestedKeys.size) { WalletUnitAttestationIssuanceFailure.NonUniqueAttestedKeys }
+            ensureNotNull(platformAttestedKeys) { WalletUnitAttestationIssuanceFailure.NoPlatformAttestedKeys }
+            ensure(platformAttestedKeys.distinct().size == platformAttestedKeys.size) {
+                WalletUnitAttestationIssuanceFailure.NonUniquePlatformAttestedKeys
+            }
 
             val validity =
                 request.preferredTtl?.let {
@@ -252,7 +254,7 @@ class IssueWalletUnitAttestationLive(
                 WalletUnitAttestationClaims(
                     issuedAt = issuedAt,
                     expiresAt = expiresAt,
-                    attestedKeys,
+                    platformAttestedKeys,
                     keyStorage = nonEmptyListOf(AttackPotentialResistance.Iso18045High),
                     userAuthentication = nonEmptyListOf(AttackPotentialResistance.Iso18045High),
                     certification,

--- a/wallet-provider-service/src/main/kotlin/port/output/platformkeyattestation/ValidatePlatformKeyAttestation.kt
+++ b/wallet-provider-service/src/main/kotlin/port/output/platformkeyattestation/ValidatePlatformKeyAttestation.kt
@@ -13,29 +13,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package eu.europa.ec.eudi.walletprovider.port.output.keyattestation
+package eu.europa.ec.eudi.walletprovider.port.output.platformkeyattestation
 
 import arrow.core.Either
 import at.asitplus.attestation.AttestationException
 import at.asitplus.signum.indispensable.Attestation
 import eu.europa.ec.eudi.walletprovider.domain.NonBlankString
-import eu.europa.ec.eudi.walletprovider.domain.keyattestation.AttestedKey
+import eu.europa.ec.eudi.walletprovider.domain.platformkeyattestation.PlatformAttestedKey
 
-fun interface ValidateKeyAttestation {
+fun interface ValidatePlatformKeyAttestation {
     suspend operator fun invoke(
         unvalidatedKeyAttestation: Attestation,
         challenge: ByteArray,
-    ): Either<KeyAttestationValidationFailure, AttestedKey>
+    ): Either<PlatformKeyAttestationValidationFailure, PlatformAttestedKey>
 }
 
-sealed interface KeyAttestationValidationFailure {
-    class InvalidKeyAttestation(
+sealed interface PlatformKeyAttestationValidationFailure {
+    class InvalidPlatformKeyAttestation(
         val error: NonBlankString,
         val cause: AttestationException? = null,
-    ) : KeyAttestationValidationFailure
+    ) : PlatformKeyAttestationValidationFailure
 
-    class UnsupportedAttestedKey(
+    class UnsupportedPlatformAttestedKey(
         val error: NonBlankString,
         val cause: Throwable? = null,
-    ) : KeyAttestationValidationFailure
+    ) : PlatformKeyAttestationValidationFailure
 }


### PR DESCRIPTION
This PR renames `Key Attestation` to `Platform Key Attestation`.

All related classes, enum constants, properties, variables have been renamed as needed.