### PR TITLE
Add JAdES Baseline B signature support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,7 @@ misc.xml
 deploymentTargetDropDown.xml
 render.experimental.xml
 *.jks
+!**/**/test/resources/*.jks
 *.keystore
 google-services.json
 *.hprof

--- a/README.md
+++ b/README.md
@@ -250,6 +250,15 @@ Variable: `DATABASE_PASSWORD`
 Description: Password of the database user.  
 Default value: N/A
 
+#### Attestation Signer Configuration
+
+Variable: `SIGNERTYPE`  
+Description: Type of signer to use for signing Attestations.  
+Default value: `JOSE`    
+Supported values:
+* `JOSE` - JSON Web Signature
+* `JAdES` - Baseline B JSON Advanced Electronic Signature
+
 #### Attestation Signing Key Configuration
 
 To load a signing key and certificate from a Keystore, use the following environment variables:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ r2dbc-pool = "1.0.2.RELEASE"
 testcontainers = "2.0.5"
 jdbc-mysql = "9.7.0"
 reactor = "2025.0.6"
+dss = "6.4"
 
 [libraries]
 kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
@@ -83,6 +84,9 @@ testcontainers-bom = { module = "org.testcontainers:testcontainers-bom", version
 testcontainers-mysql = { module = "org.testcontainers:testcontainers-mysql" }
 jdbc-mysql = { module = "com.mysql:mysql-connector-j", version.ref = "jdbc-mysql" }
 reactor-bom = { module = "io.projectreactor:reactor-bom", version.ref = "reactor" }
+dss-bom = { module = "eu.europa.ec.joinup.sd-dss:dss-bom", version.ref = "dss" }
+dss-jades = { module = "eu.europa.ec.joinup.sd-dss:dss-jades" }
+dss-utils-apache-commons = { module = "eu.europa.ec.joinup.sd-dss:dss-utils-apache-commons" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/wallet-provider-service/build.gradle.kts
+++ b/wallet-provider-service/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     implementation(enforcedPlatform(libs.ktor.bom))
     implementation(enforcedPlatform(libs.slf4j.bom))
     implementation(enforcedPlatform(libs.arrow.bom))
+    implementation(enforcedPlatform(libs.dss.bom))
     components.all<VirtualPlatformAlignmentRule> {
         val virtualPlatform = libs.bouncycastle.bom.get()
         params(virtualPlatform.group, virtualPlatform.name)
@@ -62,6 +63,9 @@ dependencies {
     implementation(libs.warden.makoto)
     implementation(libs.indispensable.josef)
     implementation(libs.supreme)
+
+    implementation(libs.dss.jades)
+    implementation(libs.dss.utils.apache.commons)
 
     implementation(libs.hoplite.core)
 

--- a/wallet-provider-service/src/main/kotlin/adapter/crypto/jades/JadesSignJwt.kt
+++ b/wallet-provider-service/src/main/kotlin/adapter/crypto/jades/JadesSignJwt.kt
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2025-2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.walletprovider.adapter.crypto.jades
+
+import arrow.core.NonEmptyList
+import arrow.core.raise.context.result
+import arrow.core.toNonEmptyListOrNull
+import at.asitplus.signum.indispensable.josef.JwsAlgorithm
+import at.asitplus.signum.indispensable.josef.JwsCompactTyped
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
+import at.asitplus.signum.indispensable.josef.toJwsAlgorithm
+import at.asitplus.signum.indispensable.pki.CertificateChain
+import at.asitplus.signum.indispensable.pki.X509Certificate
+import at.asitplus.signum.indispensable.toJcaCertificate
+import at.asitplus.signum.supreme.sign.Signer
+import at.asitplus.signum.supreme.signature
+import eu.europa.ec.eudi.walletprovider.domain.JwtType
+import eu.europa.ec.eudi.walletprovider.domain.RFC7515
+import eu.europa.ec.eudi.walletprovider.port.output.crypto.SignJwt
+import eu.europa.esig.dss.model.DSSDocument
+import kotlinx.serialization.SerializationStrategy
+import kotlinx.serialization.serializer
+import eu.europa.esig.dss.enumerations.JWSSerializationType as DSSJWSSerializationType
+import eu.europa.esig.dss.enumerations.MimeType as DSSMimeType
+import eu.europa.esig.dss.enumerations.SignatureAlgorithm as DSSSignatureAlgorithm
+import eu.europa.esig.dss.enumerations.SignatureLevel as DSSSignatureLevel
+import eu.europa.esig.dss.enumerations.SignaturePackaging as DSSSignaturePackaging
+import eu.europa.esig.dss.jades.JAdESSignatureParameters as DSSJAdESSignatureParameters
+import eu.europa.esig.dss.jades.signature.JAdESBuilder as DSSJAdESBuilder
+import eu.europa.esig.dss.jades.signature.JAdESCompactBuilder as DSSJAdESCompactBuilder
+import eu.europa.esig.dss.jades.signature.JAdESLevelBaselineB as DSSJAdESLevelBaselineB
+import eu.europa.esig.dss.jades.signature.JAdESService as DSSJAdESService
+import eu.europa.esig.dss.jades.validation.JWS as DSSJWS
+import eu.europa.esig.dss.model.InMemoryDocument as DSSInMemoryDocument
+import eu.europa.esig.dss.model.SignatureValue as DSSSignatureValue
+import eu.europa.esig.dss.model.x509.CertificateToken as DSSCertificateToken
+import eu.europa.esig.dss.spi.validation.CertificateVerifier as DSSCertificateVerifier
+import eu.europa.esig.dss.spi.validation.CommonCertificateVerifier as DSSCommonCertificateVerifier
+
+class JadesSignJwt<T : Any> private constructor(
+    private val signer: Signer,
+    private val certificateChain: NonEmptyList<DSSCertificateToken>,
+    type: JwtType,
+    private val serializer: SerializationStrategy<T>,
+    private val parse: (String) -> JwsCompactTyped<T>,
+) : SignJwt<T> {
+    override val signingAlgorithm: JwsAlgorithm
+        get() = signer.signatureAlgorithm.toJwsAlgorithm().getOrThrow()
+
+    private val service = JAdESService(type, DSSCommonCertificateVerifier())
+
+    override suspend fun invoke(claims: T): JwsCompactTyped<T> {
+        val payload = joseCompliantSerializer.encodeToString(serializer, claims).encodeToByteArray()
+        val unsignedDocument = DSSInMemoryDocument(payload)
+        val parameters =
+            DSSJAdESSignatureParameters().apply {
+                signatureLevel = DSSSignatureLevel.JAdES_BASELINE_B
+                signaturePackaging = DSSSignaturePackaging.ENVELOPING
+                jwsSerializationType = DSSJWSSerializationType.COMPACT_SERIALIZATION
+                signingCertificate = this@JadesSignJwt.certificateChain.first()
+                signingAlgorithm.toDSS().getOrThrow().let {
+                    encryptionAlgorithm = it.encryptionAlgorithm
+                    digestAlgorithm = it.digestAlgorithm
+                }
+                this.certificateChain = this@JadesSignJwt.certificateChain.map { it }
+            }
+        val unsignedData = service.getDataToSign(unsignedDocument, parameters)
+        val signature = signer.sign(unsignedData.bytes).signature
+        val signedDocument =
+            service.signDocument(
+                unsignedDocument,
+                parameters,
+                DSSSignatureValue(signingAlgorithm.toDSS().getOrThrow(), signature.rawByteArray),
+            )
+        val serializedSignedDocument = signedDocument.openStream().bufferedReader().use { it.readText() }
+        return parse(serializedSignedDocument)
+    }
+
+    companion object {
+        internal suspend inline operator fun <reified T : Any> invoke(
+            signer: Signer,
+            certificateChain: CertificateChain,
+            type: JwtType,
+        ): JadesSignJwt<T> {
+            val jwsAlgorithm =
+                signer.signatureAlgorithm.toJwsAlgorithm().getOrElse {
+                    throw IllegalArgumentException("signer is not using a JwsAlgorithm", it)
+                }
+            val dssAlgorithm =
+                jwsAlgorithm.toDSS().getOrElse {
+                    throw IllegalArgumentException("signer is not using a JwsAlgorithm supported by DSS", it)
+                }
+            val certificateChain = certificateChain.map { it.toDSS().getOrThrow() }.toNonEmptyListOrNull()
+            requireNotNull(certificateChain) {
+                "certificateChain is required for JAdES"
+            }
+
+            return JadesSignJwt(
+                signer,
+                certificateChain,
+                type,
+                serializer<T>(),
+            ) { JwsCompactTyped(it) }
+        }
+    }
+}
+
+private fun JwsAlgorithm.toDSS(): Result<DSSSignatureAlgorithm> =
+    result {
+        when (this) {
+            JwsAlgorithm.MAC.HS256 -> DSSSignatureAlgorithm.HMAC_SHA256
+            JwsAlgorithm.MAC.HS384 -> DSSSignatureAlgorithm.HMAC_SHA384
+            JwsAlgorithm.MAC.HS512 -> DSSSignatureAlgorithm.HMAC_SHA512
+            JwsAlgorithm.Signature.EC.ES256 -> DSSSignatureAlgorithm.ECDSA_SHA256
+            JwsAlgorithm.Signature.EC.ES384 -> DSSSignatureAlgorithm.ECDSA_SHA384
+            JwsAlgorithm.Signature.EC.ES512 -> DSSSignatureAlgorithm.ECDSA_SHA512
+            JwsAlgorithm.Signature.RSA.RS256 -> DSSSignatureAlgorithm.RSA_SHA256
+            JwsAlgorithm.Signature.RSA.RS384 -> DSSSignatureAlgorithm.RSA_SHA384
+            JwsAlgorithm.Signature.RSA.RS512 -> DSSSignatureAlgorithm.RSA_SHA512
+            JwsAlgorithm.Signature.RSA.PS256 -> DSSSignatureAlgorithm.RSA_SSA_PSS_SHA256_MGF1
+            JwsAlgorithm.Signature.RSA.PS384 -> DSSSignatureAlgorithm.RSA_SSA_PSS_SHA384_MGF1
+            JwsAlgorithm.Signature.RSA.PS512 -> DSSSignatureAlgorithm.RSA_SSA_PSS_SHA512_MGF1
+            else -> throw UnsupportedOperationException("Unsupported algorithm: $this")
+        }
+    }
+
+private suspend fun X509Certificate.toDSS(): Result<DSSCertificateToken> =
+    result {
+        DSSCertificateToken(toJcaCertificate().getOrThrow())
+    }
+
+private class JAdESBaselineB(
+    private val type: JwtType,
+    certificateVerifier: DSSCertificateVerifier,
+    signatureParameters: DSSJAdESSignatureParameters,
+    documentsToSign: List<DSSDocument>,
+) : DSSJAdESLevelBaselineB(certificateVerifier, signatureParameters, documentsToSign) {
+    override fun incorporateType() {
+        addHeader(RFC7515.TYPE, type.value)
+    }
+}
+
+private class JAdESBuilder(
+    private val jwtType: JwtType,
+    certificateVerifier: DSSCertificateVerifier,
+    signatureParameters: DSSJAdESSignatureParameters,
+    documentsToSign: List<DSSDocument>,
+) : DSSJAdESCompactBuilder(certificateVerifier, signatureParameters, documentsToSign) {
+    private val jadesBaselineB = JAdESBaselineB(jwtType, certificateVerifier, signatureParameters, documentsToSign)
+
+    override fun incorporateHeader(jws: DSSJWS) {
+        jadesBaselineB.signedProperties.forEach { (claim, value) -> jws.setHeader(claim, value) }
+    }
+
+    override fun getMimeType(): DSSMimeType =
+        object : DSSMimeType {
+            override fun getMimeTypeString(): String = "application/${jwtType.value}"
+
+            override fun getExtension(): String = "jwt"
+        }
+
+    override fun incorporatePayload(jws: DSSJWS) {
+        val payload = jadesBaselineB.payloadBytes
+        if (null != payload && payload.isNotEmpty()) {
+            jws.setPayloadOctets(payload)
+        }
+    }
+}
+
+private class JAdESService(
+    private val jwtType: JwtType,
+    certificateVerifier: DSSCertificateVerifier,
+) : DSSJAdESService(certificateVerifier) {
+    override fun getJAdESBuilder(
+        parameters: DSSJAdESSignatureParameters,
+        documentsToSign: List<DSSDocument>,
+    ): DSSJAdESBuilder = JAdESBuilder(jwtType, certificateVerifier, parameters, documentsToSign)
+}

--- a/wallet-provider-service/src/main/kotlin/adapter/crypto/jose/JoseSignJwt.kt
+++ b/wallet-provider-service/src/main/kotlin/adapter/crypto/jose/JoseSignJwt.kt
@@ -13,16 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package eu.europa.ec.eudi.walletprovider.adapter.jose
+package eu.europa.ec.eudi.walletprovider.adapter.crypto.jose
 
 import at.asitplus.signum.indispensable.josef.*
 import at.asitplus.signum.indispensable.pki.CertificateChain
 import at.asitplus.signum.supreme.sign.Signer
 import at.asitplus.signum.supreme.signature
 import eu.europa.ec.eudi.walletprovider.domain.JwtType
-import eu.europa.ec.eudi.walletprovider.port.output.jose.SignJwt
+import eu.europa.ec.eudi.walletprovider.port.output.crypto.SignJwt
 
-inline fun <reified T : Any> SignJwt(
+@Suppress("FunctionName")
+inline fun <reified T : Any> JoseSignJwt(
     signer: Signer,
     certificateChain: CertificateChain?,
     type: JwtType,

--- a/wallet-provider-service/src/main/kotlin/adapter/crypto/jose/JoseSignJwt.kt
+++ b/wallet-provider-service/src/main/kotlin/adapter/crypto/jose/JoseSignJwt.kt
@@ -27,10 +27,15 @@ inline fun <reified T : Any> JoseSignJwt(
     signer: Signer,
     certificateChain: CertificateChain?,
     type: JwtType,
-): SignJwt<T> =
-    object : SignJwt<T> {
+): SignJwt<T> {
+    val signingAlgorithm =
+        signer.signatureAlgorithm.toJwsAlgorithm().getOrElse {
+            throw IllegalArgumentException("signer is not using a JwsAlgorithm", it)
+        }
+
+    return object : SignJwt<T> {
         override val signingAlgorithm: JwsAlgorithm
-            get() = signer.signatureAlgorithm.toJwsAlgorithm().getOrThrow()
+            get() = signingAlgorithm
 
         override suspend fun invoke(claims: T): JwsCompactTyped<T> {
             val header =
@@ -50,3 +55,4 @@ inline fun <reified T : Any> JoseSignJwt(
             }
         }
     }
+}

--- a/wallet-provider-service/src/main/kotlin/adapter/crypto/jose/JoseValidateJwtSignature.kt
+++ b/wallet-provider-service/src/main/kotlin/adapter/crypto/jose/JoseValidateJwtSignature.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package eu.europa.ec.eudi.walletprovider.adapter.jose
+package eu.europa.ec.eudi.walletprovider.adapter.crypto.jose
 
 import arrow.core.raise.catch
 import arrow.core.raise.context.raise
@@ -23,10 +23,11 @@ import at.asitplus.signum.supreme.sign.Verifier
 import at.asitplus.signum.supreme.sign.verifierFor
 import at.asitplus.signum.supreme.sign.verify
 import eu.europa.ec.eudi.walletprovider.domain.toNonBlankString
-import eu.europa.ec.eudi.walletprovider.port.output.jose.JwtSignatureValidationFailure
-import eu.europa.ec.eudi.walletprovider.port.output.jose.ValidateJwtSignature
+import eu.europa.ec.eudi.walletprovider.port.output.crypto.JwtSignatureValidationFailure
+import eu.europa.ec.eudi.walletprovider.port.output.crypto.ValidateJwtSignature
 
-inline fun <reified T : Any> ValidateJwtSignature(verifier: Verifier): ValidateJwtSignature<T> =
+@Suppress("FunctionName")
+inline fun <reified T : Any> JoseValidateJwtSignature(verifier: Verifier): ValidateJwtSignature<T> =
     ValidateJwtSignature { unvalidated ->
         val parsed =
             catch({
@@ -54,5 +55,6 @@ inline fun <reified T : Any> ValidateJwtSignature(verifier: Verifier): ValidateJ
         parsed
     }
 
-inline fun <reified T : Any> ValidateJwtSignature(singer: Signer): ValidateJwtSignature<T> =
-    ValidateJwtSignature(singer.signatureAlgorithm.verifierFor(singer.publicKey).getOrThrow())
+@Suppress("FunctionName")
+inline fun <reified T : Any> JoseValidateJwtSignature(singer: Signer): ValidateJwtSignature<T> =
+    JoseValidateJwtSignature(singer.signatureAlgorithm.verifierFor(singer.publicKey).getOrThrow())

--- a/wallet-provider-service/src/main/kotlin/config/WalletProviderApplication.kt
+++ b/wallet-provider-service/src/main/kotlin/config/WalletProviderApplication.kt
@@ -23,6 +23,7 @@ import eu.europa.ec.eudi.walletprovider.domain.time.Clock
 import io.ktor.client.*
 import io.ktor.serialization.kotlinx.json.*
 import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import io.ktor.client.engine.cio.CIO as CIOClientEngine
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation as ClientContentNegotiation
@@ -68,15 +69,17 @@ object WalletProviderApplication {
                     grace = config.server.grace.value,
                     timeout = config.server.timeout.value,
                 ) {
-                    configureWalletProviderModule(
-                        config,
-                        clock,
-                        json,
-                        database,
-                        signer,
-                        certificateChain,
-                        httpClient,
-                    )
+                    runBlocking {
+                        configureWalletProviderModule(
+                            config,
+                            clock,
+                            json,
+                            database,
+                            signer,
+                            certificateChain,
+                            httpClient,
+                        )
+                    }
                 }
                 awaitCancellation()
             }

--- a/wallet-provider-service/src/main/kotlin/config/WalletProviderConfiguration.kt
+++ b/wallet-provider-service/src/main/kotlin/config/WalletProviderConfiguration.kt
@@ -40,6 +40,7 @@ import kotlin.time.Duration.Companion.seconds
 data class WalletProviderConfiguration(
     val server: ServerConfiguration = ServerConfiguration(),
     val database: DatabaseConfiguration,
+    val signerType: SignerType = SignerType.JOSE,
     val signingKey: SigningKeyConfiguration,
     val platformKeyAttestationValidation: PlatformKeyAttestationValidationConfiguration = PlatformKeyAttestationValidationConfiguration.Disabled,
     val challenge: ChallengeConfiguration = ChallengeConfiguration(),
@@ -84,6 +85,11 @@ value class ZeroOrPositiveDuration(
     }
 
     override fun toString(): String = value.toString()
+}
+
+enum class SignerType {
+    JOSE,
+    JAdES,
 }
 
 data class SigningKeyConfiguration(

--- a/wallet-provider-service/src/main/kotlin/config/WalletProviderModuleConfiguration.kt
+++ b/wallet-provider-service/src/main/kotlin/config/WalletProviderModuleConfiguration.kt
@@ -21,7 +21,7 @@ import at.asitplus.attestation.NoopAttestationService
 import at.asitplus.attestation.android.AndroidAttestationConfiguration
 import at.asitplus.signum.indispensable.pki.CertificateChain
 import at.asitplus.signum.supreme.sign.Signer
-import eu.europa.ec.eudi.walletprovider.adapter.jose.SignJwt
+import eu.europa.ec.eudi.walletprovider.adapter.crypto.jose.JoseSignJwt
 import eu.europa.ec.eudi.walletprovider.adapter.persistence.RunInTransactionLive
 import eu.europa.ec.eudi.walletprovider.adapter.persistence.challenge.ChallengeRepositoryLive
 import eu.europa.ec.eudi.walletprovider.adapter.platformkeyattestation.MakotoValidatePlatformKeyAttestation
@@ -121,7 +121,7 @@ fun Application.configureWalletProviderModule(
             config.walletInstanceAttestation.walletSolutionCertificationInformation,
             config.walletInstanceAttestation.clientStatusValidity,
             generateStatusListToken,
-            SignJwt(
+            JoseSignJwt(
                 signer,
                 certificateChain,
                 JwtType(AttestationBasedClientAuthenticationSpec.CLIENT_ATTESTATION_JWT_TYPE),
@@ -136,7 +136,7 @@ fun Application.configureWalletProviderModule(
             config.keyAttestation.validity,
             generateStatusListToken,
             config.keyAttestation.certification,
-            SignJwt(
+            JoseSignJwt(
                 signer,
                 certificateChain,
                 JwtType(OpenId4VCISpec.KEY_ATTESTATION_JWT_TYPE),

--- a/wallet-provider-service/src/main/kotlin/config/WalletProviderModuleConfiguration.kt
+++ b/wallet-provider-service/src/main/kotlin/config/WalletProviderModuleConfiguration.kt
@@ -21,6 +21,7 @@ import at.asitplus.attestation.NoopAttestationService
 import at.asitplus.attestation.android.AndroidAttestationConfiguration
 import at.asitplus.signum.indispensable.pki.CertificateChain
 import at.asitplus.signum.supreme.sign.Signer
+import eu.europa.ec.eudi.walletprovider.adapter.crypto.jades.JadesSignJwt
 import eu.europa.ec.eudi.walletprovider.adapter.crypto.jose.JoseSignJwt
 import eu.europa.ec.eudi.walletprovider.adapter.persistence.RunInTransactionLive
 import eu.europa.ec.eudi.walletprovider.adapter.persistence.challenge.ChallengeRepositoryLive
@@ -38,6 +39,7 @@ import eu.europa.ec.eudi.walletprovider.port.input.keyattestation.IssueKeyAttest
 import eu.europa.ec.eudi.walletprovider.port.input.walletinstanceattestation.IssueWalletInstanceAttestationLive
 import eu.europa.ec.eudi.walletprovider.port.output.challenge.ValidateChallengeLive
 import eu.europa.ec.eudi.walletprovider.port.output.challenge.ValidateChallengeNoop
+import eu.europa.ec.eudi.walletprovider.port.output.crypto.SignJwt
 import io.ktor.client.*
 import io.ktor.client.engine.cio.*
 import io.ktor.http.*
@@ -59,7 +61,7 @@ import at.asitplus.attestation.AttestationService as MakotoAttestationService
 
 private val logger = LoggerFactory.getLogger("WalletProviderModule")
 
-fun Application.configureWalletProviderModule(
+suspend fun Application.configureWalletProviderModule(
     config: WalletProviderConfiguration,
     clock: Clock,
     json: Json,
@@ -121,7 +123,7 @@ fun Application.configureWalletProviderModule(
             config.walletInstanceAttestation.walletSolutionCertificationInformation,
             config.walletInstanceAttestation.clientStatusValidity,
             generateStatusListToken,
-            JoseSignJwt(
+            config.signerType.signJwt(
                 signer,
                 certificateChain,
                 JwtType(AttestationBasedClientAuthenticationSpec.CLIENT_ATTESTATION_JWT_TYPE),
@@ -136,7 +138,7 @@ fun Application.configureWalletProviderModule(
             config.keyAttestation.validity,
             generateStatusListToken,
             config.keyAttestation.certification,
-            JoseSignJwt(
+            config.signerType.signJwt(
                 signer,
                 certificateChain,
                 JwtType(OpenId4VCISpec.KEY_ATTESTATION_JWT_TYPE),
@@ -174,6 +176,16 @@ private fun Application.configureServerPlugins(
         }
     }
 }
+
+private suspend inline fun <reified T : Any> SignerType.signJwt(
+    signer: Signer,
+    certificateChain: CertificateChain,
+    type: JwtType,
+): SignJwt<T> =
+    when (this) {
+        SignerType.JOSE -> JoseSignJwt(signer, certificateChain, type)
+        SignerType.JAdES -> JadesSignJwt(signer, certificateChain, type)
+    }
 
 private fun createMakotoAttestationService(
     config: WalletProviderConfiguration,

--- a/wallet-provider-service/src/main/kotlin/domain/Specs.kt
+++ b/wallet-provider-service/src/main/kotlin/domain/Specs.kt
@@ -15,6 +15,7 @@
  */
 package eu.europa.ec.eudi.walletprovider.domain
 
+import at.asitplus.signum.indispensable.josef.JwsAlgorithm
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
@@ -99,4 +100,17 @@ object TS3 {
     const val WALLET_SOLUTION_CERTIFICATION_INFORMATION: String = "wallet_solution_certification_information"
     const val CLIENT_STATUS: String = "client_status"
     const val KEY_STORAGE_STATUS: String = "key_storage_status"
+    val ALLOWED_SIGNATURE_ALGORITHMS: Set<JwsAlgorithm.Signature.EC> =
+        setOf(
+            JwsAlgorithm.Signature.EC.ES256,
+            JwsAlgorithm.Signature.EC.ES384,
+            JwsAlgorithm.Signature.EC.ES512,
+        )
+}
+
+/**
+ * [JSON Web Signature (JWS)](https://www.rfc-editor.org/info/rfc7515)
+ */
+object RFC7515 {
+    const val TYPE: String = "typ"
 }

--- a/wallet-provider-service/src/main/kotlin/port/input/keyattestation/IssueKeyAttestation.kt
+++ b/wallet-provider-service/src/main/kotlin/port/input/keyattestation/IssueKeyAttestation.kt
@@ -33,7 +33,7 @@ import eu.europa.ec.eudi.walletprovider.domain.keyattestation.*
 import eu.europa.ec.eudi.walletprovider.domain.time.Clock
 import eu.europa.ec.eudi.walletprovider.domain.tokenstatuslist.Status
 import eu.europa.ec.eudi.walletprovider.port.output.challenge.ValidateChallenge
-import eu.europa.ec.eudi.walletprovider.port.output.jose.SignJwt
+import eu.europa.ec.eudi.walletprovider.port.output.crypto.SignJwt
 import eu.europa.ec.eudi.walletprovider.port.output.platformkeyattestation.PlatformKeyAttestationValidationFailure
 import eu.europa.ec.eudi.walletprovider.port.output.platformkeyattestation.ValidatePlatformKeyAttestation
 import eu.europa.ec.eudi.walletprovider.port.output.tokenstatuslist.AllocateStatusListToken

--- a/wallet-provider-service/src/main/kotlin/port/input/keyattestation/IssueKeyAttestation.kt
+++ b/wallet-provider-service/src/main/kotlin/port/input/keyattestation/IssueKeyAttestation.kt
@@ -179,6 +179,13 @@ class IssueKeyAttestationLive(
     private val signJwt: SignJwt<KeyAttestationClaims>,
     private val preferredKeyStorageStatusPeriod: PositiveDuration,
 ) : IssueKeyAttestation {
+    init {
+        require(signJwt.signingAlgorithm in TS3.ALLOWED_SIGNATURE_ALGORITHMS) {
+            "Key Attestations must be signed using one of the following JWS Algorithms: " +
+                TS3.ALLOWED_SIGNATURE_ALGORITHMS.joinToString { it.identifier }
+        }
+    }
+
     context(_: Raise<KeyAttestationIssuanceFailure>)
     override suspend fun invoke(request: KeyAttestationIssuanceRequest): KeyAttestation {
         val supportedSigningAlgorithm = signJwt.signingAlgorithm

--- a/wallet-provider-service/src/main/kotlin/port/input/walletinstanceattestation/IssueWalletInstanceAttestation.kt
+++ b/wallet-provider-service/src/main/kotlin/port/input/walletinstanceattestation/IssueWalletInstanceAttestation.kt
@@ -178,6 +178,13 @@ class IssueWalletInstanceAttestationLive(
     private val allocateStatusListToken: AllocateStatusListToken,
     private val signJwt: SignJwt<WalletInstanceAttestationClaims>,
 ) : IssueWalletInstanceAttestation {
+    init {
+        require(signJwt.signingAlgorithm in TS3.ALLOWED_SIGNATURE_ALGORITHMS) {
+            "Wallet Instance Attestations must be signed using one of the following JWS Algorithms: " +
+                TS3.ALLOWED_SIGNATURE_ALGORITHMS.joinToString { it.identifier }
+        }
+    }
+
     context(_: Raise<WalletInstanceAttestationIssuanceFailure>)
     override suspend fun invoke(request: WalletInstanceAttestationIssuanceRequest): WalletInstanceAttestation {
         val supportedSigningAlgorithm = signJwt.signingAlgorithm
@@ -216,7 +223,7 @@ class IssueWalletInstanceAttestationLive(
         }
 
         val platformAttestedKeyCurve = checkNotNull(platformAttestedKey.curve) { "Platform Attested Key is missing `crv` claim" }
-        ensure(platformAttestedKeyCurve in setOf(ECCurve.SECP_256_R_1, ECCurve.SECP_384_R_1, ECCurve.SECP_521_R_1)) {
+        ensure(platformAttestedKeyCurve in TS3.ALLOWED_SIGNATURE_ALGORITHMS.map { it.ecCurve }) {
             WalletInstanceAttestationIssuanceFailure.UnsupportedPlatformAttestedKeyCurve(platformAttestedKeyCurve)
         }
 

--- a/wallet-provider-service/src/main/kotlin/port/input/walletinstanceattestation/IssueWalletInstanceAttestation.kt
+++ b/wallet-provider-service/src/main/kotlin/port/input/walletinstanceattestation/IssueWalletInstanceAttestation.kt
@@ -31,7 +31,7 @@ import eu.europa.ec.eudi.walletprovider.domain.tokenstatuslist.Status
 import eu.europa.ec.eudi.walletprovider.domain.walletinstanceattestation.*
 import eu.europa.ec.eudi.walletprovider.domain.walletinstanceattestation.ClientStatus
 import eu.europa.ec.eudi.walletprovider.port.output.challenge.ValidateChallenge
-import eu.europa.ec.eudi.walletprovider.port.output.jose.SignJwt
+import eu.europa.ec.eudi.walletprovider.port.output.crypto.SignJwt
 import eu.europa.ec.eudi.walletprovider.port.output.platformkeyattestation.PlatformKeyAttestationValidationFailure
 import eu.europa.ec.eudi.walletprovider.port.output.platformkeyattestation.ValidatePlatformKeyAttestation
 import eu.europa.ec.eudi.walletprovider.port.output.tokenstatuslist.AllocateStatusListToken

--- a/wallet-provider-service/src/main/kotlin/port/output/crypto/SignJwt.kt
+++ b/wallet-provider-service/src/main/kotlin/port/output/crypto/SignJwt.kt
@@ -13,25 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package eu.europa.ec.eudi.walletprovider.port.output.jose
+package eu.europa.ec.eudi.walletprovider.port.output.crypto
 
-import arrow.core.raise.context.Raise
+import at.asitplus.signum.indispensable.josef.JwsAlgorithm
 import at.asitplus.signum.indispensable.josef.JwsCompactTyped
-import eu.europa.ec.eudi.walletprovider.domain.NonBlankString
 
-fun interface ValidateJwtSignature<T : Any> {
-    context(_: Raise<JwtSignatureValidationFailure>)
-    suspend operator fun invoke(unvalidated: String): JwsCompactTyped<T>
-}
+interface SignJwt<T : Any> {
+    val signingAlgorithm: JwsAlgorithm
 
-sealed interface JwtSignatureValidationFailure {
-    class UnparsableJwt(
-        val error: NonBlankString,
-        val cause: Throwable? = null,
-    ) : JwtSignatureValidationFailure
-
-    class InvalidSignature(
-        val error: NonBlankString,
-        val cause: Throwable? = null,
-    ) : JwtSignatureValidationFailure
+    suspend operator fun invoke(claims: T): JwsCompactTyped<T>
 }

--- a/wallet-provider-service/src/main/kotlin/port/output/crypto/ValidateJwtSignature.kt
+++ b/wallet-provider-service/src/main/kotlin/port/output/crypto/ValidateJwtSignature.kt
@@ -13,13 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package eu.europa.ec.eudi.walletprovider.port.output.jose
+package eu.europa.ec.eudi.walletprovider.port.output.crypto
 
-import at.asitplus.signum.indispensable.josef.JwsAlgorithm
+import arrow.core.raise.context.Raise
 import at.asitplus.signum.indispensable.josef.JwsCompactTyped
+import eu.europa.ec.eudi.walletprovider.domain.NonBlankString
 
-interface SignJwt<T : Any> {
-    val signingAlgorithm: JwsAlgorithm
+fun interface ValidateJwtSignature<T : Any> {
+    context(_: Raise<JwtSignatureValidationFailure>)
+    suspend operator fun invoke(unvalidated: String): JwsCompactTyped<T>
+}
 
-    suspend operator fun invoke(claims: T): JwsCompactTyped<T>
+sealed interface JwtSignatureValidationFailure {
+    class UnparsableJwt(
+        val error: NonBlankString,
+        val cause: Throwable? = null,
+    ) : JwtSignatureValidationFailure
+
+    class InvalidSignature(
+        val error: NonBlankString,
+        val cause: Throwable? = null,
+    ) : JwtSignatureValidationFailure
 }

--- a/wallet-provider-service/src/test/kotlin/IssueKeyAttestationTest.kt
+++ b/wallet-provider-service/src/test/kotlin/IssueKeyAttestationTest.kt
@@ -20,6 +20,7 @@ import at.asitplus.signum.indispensable.josef.JsonWebKeySet
 import at.asitplus.signum.indispensable.josef.JwsCompactTyped
 import at.asitplus.signum.indispensable.josef.toJsonWebKey
 import at.asitplus.signum.supreme.sign.EphemeralKey
+import eu.europa.ec.eudi.walletprovider.config.SignerType
 import eu.europa.ec.eudi.walletprovider.config.WalletProviderConfiguration
 import eu.europa.ec.eudi.walletprovider.domain.SecondsDuration
 import eu.europa.ec.eudi.walletprovider.domain.keyattestation.KeyAttestation
@@ -41,7 +42,13 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 import kotlin.uuid.Uuid
 
-class IssueKeyAttestationTest : WalletProviderTest() {
+abstract class IssueKeyAttestationTest(
+    signerType: SignerType,
+) : WalletProviderTest(signerType) {
+    class JOSE : IssueKeyAttestationTest(SignerType.JOSE)
+
+    class JAdES : IssueKeyAttestationTest(SignerType.JAdES)
+
     @Test
     fun `key attestation contains nonce when provided`(httpClient: HttpClient) {
         httpClient.runKeyAttestationTestCase {

--- a/wallet-provider-service/src/test/kotlin/IssueWalletInstanceAttestationTest.kt
+++ b/wallet-provider-service/src/test/kotlin/IssueWalletInstanceAttestationTest.kt
@@ -19,6 +19,7 @@ import at.asitplus.signum.indispensable.ECCurve
 import at.asitplus.signum.indispensable.josef.JwsCompactTyped
 import at.asitplus.signum.indispensable.josef.toJsonWebKey
 import at.asitplus.signum.supreme.sign.EphemeralKey
+import eu.europa.ec.eudi.walletprovider.config.SignerType
 import eu.europa.ec.eudi.walletprovider.config.WalletProviderConfiguration
 import eu.europa.ec.eudi.walletprovider.domain.SecondsDuration
 import eu.europa.ec.eudi.walletprovider.domain.time.Clock
@@ -38,7 +39,13 @@ import kotlin.test.*
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 
-class IssueWalletInstanceAttestationTest : WalletProviderTest() {
+abstract class IssueWalletInstanceAttestationTest(
+    signerType: SignerType,
+) : WalletProviderTest(signerType) {
+    class JOSE : IssueWalletInstanceAttestationTest(SignerType.JOSE)
+
+    class JAdES : IssueWalletInstanceAttestationTest(SignerType.JAdES)
+
     @Test
     fun `wallet instance attestation includes wallet metadata when provided as object`(httpClient: HttpClient) {
         val walletMetadata =

--- a/wallet-provider-service/src/test/kotlin/WalletProviderTest.kt
+++ b/wallet-provider-service/src/test/kotlin/WalletProviderTest.kt
@@ -44,6 +44,10 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
 import org.jetbrains.exposed.v1.r2dbc.deleteAll
 import org.jetbrains.exposed.v1.r2dbc.transactions.suspendTransaction
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.extension.*
 import org.slf4j.LoggerFactory
 import org.testcontainers.mysql.MySQLContainer
@@ -64,134 +68,9 @@ private val database by lazy {
 private val MySQLContainer.r2dbcUrl: String
     get() = "r2dbc:pool:mysql://$host:$firstMappedPort/$databaseName"
 
-private val log = LoggerFactory.getLogger(WalletProviderExtension::class.java)
+private val log = LoggerFactory.getLogger(WalletProviderTest::class.java)
 
 private val clock = Clock.System
-
-private class WalletProviderExtension :
-    BeforeAllCallback,
-    BeforeEachCallback,
-    AfterAllCallback,
-    ParameterResolver {
-    private val resources = ResourceScope()
-
-    private val json =
-        Json {
-            ignoreUnknownKeys = true
-            prettyPrint = true
-        }
-
-    private val config =
-        WalletProviderConfiguration(
-            database =
-                DatabaseConfiguration(
-                    url = database.r2dbcUrl.toNonBlankString(),
-                    username = database.username,
-                    password = Secret(database.password),
-                ),
-            signingKey =
-                SigningKeyConfiguration(
-                    keystoreFile = Path.of("src/test/resources/keystore.jks"),
-                    keystorePassword = Secret("testKeystore"),
-                    keyAlias = "test-key".toNonBlankString(),
-                    keyPassword = Secret("testKeystore"),
-                    algorithm = SigningAlgorithm.ES256,
-                ),
-            walletInstanceAttestation =
-                WalletInstanceAttestationConfiguration(
-                    walletName = "EUDI Wallet".toNonBlankString(),
-                    walletVersion = "1.0.0".toNonBlankString(),
-                    walletSolutionCertificationInformation = JsonPrimitive("https://github.com/eu-digital-identity-wallet"),
-                ),
-            keyAttestation =
-                KeyAttestationConfiguration(
-                    certification = StringUri.create("https://example.org/certification").toURL(),
-                ),
-            tokenStatusListService =
-                TokenStatusListServiceConfiguration(
-                    serviceUrl = URI.create("https://status.example.com/create").toURL(),
-                    apiKey = Secret("API-KEY"),
-                ),
-        )
-
-    private val testApplication: TestApplication =
-        runBlocking {
-            val database = context(resources) { config.database.connect() }
-            val (signer, certificateChain) = config.signingKey.load()
-            val httpClient = context(resources) { createMockHttpClient(config, json) }
-
-            TestApplication {
-                application {
-                    configureWalletProviderModule(
-                        config,
-                        clock,
-                        json,
-                        database,
-                        signer,
-                        certificateChain,
-                        httpClient,
-                    )
-                }
-            }
-        }
-
-    private lateinit var httpClient: HttpClient
-
-    override fun beforeAll(context: ExtensionContext) {
-        log.info("Starting TestApplication and creating HttpClient")
-        runBlocking {
-            testApplication.start()
-            httpClient =
-                resources.install(
-                    testApplication.createClient {
-                        install(ClientContentNegotiation) {
-                            json(json)
-                        }
-                    },
-                )
-        }
-    }
-
-    override fun beforeEach(context: ExtensionContext) {
-        log.info("Cleaning up database")
-        runBlocking {
-            suspendTransaction {
-                Challenges.deleteAll()
-            }
-        }
-    }
-
-    override fun afterAll(context: ExtensionContext) {
-        log.info("Stopping TestApplication and clearing ResourceScope")
-        runBlocking {
-            withContext(NonCancellable) {
-                testApplication.stop()
-                resources.releaseAll()
-            }
-        }
-    }
-
-    override fun supportsParameter(
-        parameterContext: ParameterContext,
-        extensionContext: ExtensionContext,
-    ): Boolean =
-        arrow.fx.coroutines.ResourceScope::class.java.isAssignableFrom(parameterContext.parameter.type) ||
-            HttpClient::class.java.isAssignableFrom(parameterContext.parameter.type) ||
-            WalletProviderConfiguration::class.java.isAssignableFrom(parameterContext.parameter.type) ||
-            Clock::class.java.isAssignableFrom(parameterContext.parameter.type)
-
-    override fun resolveParameter(
-        parameterContext: ParameterContext,
-        extensionContext: ExtensionContext,
-    ): Any =
-        when {
-            arrow.fx.coroutines.ResourceScope::class.java.isAssignableFrom(parameterContext.parameter.type) -> resources
-            HttpClient::class.java.isAssignableFrom(parameterContext.parameter.type) -> httpClient
-            WalletProviderConfiguration::class.java.isAssignableFrom(parameterContext.parameter.type) -> config
-            Clock::class.java.isAssignableFrom(parameterContext.parameter.type) -> clock
-            else -> throw ParameterResolutionException("Unsupported parameter type: ${parameterContext.parameter.type}")
-        }
-}
 
 @OptIn(AutoCloseImplementation::class)
 private class ResourceScope : arrow.fx.coroutines.ResourceScope {
@@ -264,5 +143,140 @@ private fun createMockHttpClient(
     )
 }
 
-@ExtendWith(WalletProviderExtension::class)
-abstract class WalletProviderTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class WalletProviderTest(
+    signerType: SignerType = SignerType.JOSE,
+) {
+    init {
+        log.info("Will run tests using SignerType: {}", signerType)
+    }
+
+    private val resources = ResourceScope()
+
+    private val json =
+        Json {
+            ignoreUnknownKeys = true
+            prettyPrint = true
+        }
+
+    private val config by lazy {
+        WalletProviderConfiguration(
+            database =
+                DatabaseConfiguration(
+                    url = database.r2dbcUrl.toNonBlankString(),
+                    username = database.username,
+                    password = Secret(database.password),
+                ),
+            signerType = signerType,
+            signingKey =
+                SigningKeyConfiguration(
+                    keystoreFile = Path.of("src/test/resources/keystore.jks"),
+                    keystorePassword = Secret("testKeystore"),
+                    keyAlias = "test-key".toNonBlankString(),
+                    keyPassword = Secret("testKeystore"),
+                    algorithm = SigningAlgorithm.ES256,
+                ),
+            walletInstanceAttestation =
+                WalletInstanceAttestationConfiguration(
+                    walletName = "EUDI Wallet".toNonBlankString(),
+                    walletVersion = "1.0.0".toNonBlankString(),
+                    walletSolutionCertificationInformation = JsonPrimitive("https://github.com/eu-digital-identity-wallet"),
+                ),
+            keyAttestation =
+                KeyAttestationConfiguration(
+                    certification = StringUri.create("https://example.org/certification").toURL(),
+                ),
+            tokenStatusListService =
+                TokenStatusListServiceConfiguration(
+                    serviceUrl = URI.create("https://status.example.com/create").toURL(),
+                    apiKey = Secret("API-KEY"),
+                ),
+        )
+    }
+
+    private val testApplication: TestApplication by lazy {
+        runBlocking {
+            val database = context(resources) { config.database.connect() }
+            val (signer, certificateChain) = config.signingKey.load()
+            val httpClient = context(resources) { createMockHttpClient(config, json) }
+
+            TestApplication {
+                application {
+                    configureWalletProviderModule(
+                        config,
+                        clock,
+                        json,
+                        database,
+                        signer,
+                        certificateChain,
+                        httpClient,
+                    )
+                }
+            }
+        }
+    }
+
+    private lateinit var httpClient: HttpClient
+
+    @RegisterExtension
+    val parameterResolver =
+        object : ParameterResolver {
+            override fun supportsParameter(
+                parameterContext: ParameterContext,
+                extensionContext: ExtensionContext,
+            ): Boolean =
+                arrow.fx.coroutines.ResourceScope::class.java.isAssignableFrom(parameterContext.parameter.type) ||
+                    HttpClient::class.java.isAssignableFrom(parameterContext.parameter.type) ||
+                    WalletProviderConfiguration::class.java.isAssignableFrom(parameterContext.parameter.type) ||
+                    Clock::class.java.isAssignableFrom(parameterContext.parameter.type)
+
+            override fun resolveParameter(
+                parameterContext: ParameterContext,
+                extensionContext: ExtensionContext,
+            ): Any =
+                when {
+                    arrow.fx.coroutines.ResourceScope::class.java.isAssignableFrom(parameterContext.parameter.type) -> resources
+                    HttpClient::class.java.isAssignableFrom(parameterContext.parameter.type) -> httpClient
+                    WalletProviderConfiguration::class.java.isAssignableFrom(parameterContext.parameter.type) -> config
+                    Clock::class.java.isAssignableFrom(parameterContext.parameter.type) -> clock
+                    else -> throw ParameterResolutionException("Unsupported parameter type: ${parameterContext.parameter.type}")
+                }
+        }
+
+    @BeforeAll
+    fun beforeAll() {
+        log.info("Starting TestApplication and creating HttpClient")
+        runBlocking {
+            testApplication.start()
+            httpClient =
+                resources.install(
+                    testApplication.createClient {
+                        install(ClientContentNegotiation) {
+                            json(json)
+                        }
+                    },
+                )
+        }
+    }
+
+    @BeforeEach
+    fun beforeEach() {
+        log.info("Cleaning up database")
+        runBlocking {
+            suspendTransaction {
+                Challenges.deleteAll()
+            }
+        }
+    }
+
+    @AfterAll
+    fun afterAll() {
+        log.info("Stopping TestApplication and clearing ResourceScope")
+        runBlocking {
+            withContext(NonCancellable) {
+                testApplication.stop()
+                resources.releaseAll()
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for signing Wallet Unit Attestations (WIA and KA) with JAdES Baseline B using Compact Serialization.

JAdES signed JWTs, are JWTs with a JSON Web Signature that contain extra claims in the Protected Header and/or Claims Set.

Given the above, this PR introduces DSS as a dependency and uses DSS facilities to generate the Protected Header and Claims Set to be signed, and signs the payload using the already configured Signum `Signer`.

`SignJwt<T>` has been updated to return a serialized signed JWT, as a `NonBlankString`, instead of a `JwsSigned<T>`. The Signum `JwsHeader` doesn't contain the extra JAdES claims, and a such `JwsSigned<T>` is inappropriate for deserializing a JAdES signed JWT.

Unfortunately `JAdESService` uses a `JAdESCompactBuilder` with a `JAdESLevelBaselineB` instance that hardcodes the `typ` claim in the Protected Header to the value `JOSE`.
To be fully compliant with Attestation Based Client Authentication, OpenId4VCI, and TS3, `JadesSignJwt` uses classes that override this behavior and properly set `typ` to either `oauth-client-attestation+jwt` or `key-attestation+jwt` as expected.

With the current implementation the signature check in https://jwt.io passes.

Additionally, all check performed by the JAdES Signature Checker at https://signatures-conformance-checker.etsi.org pass, besides check 26 which relates to the `typ` claim in the Protected Header.

<img width="1706" height="3547" alt="signatures-conformance-checker etsi org_check-results_jades_ 22 _b4261447-8f93-4c61-a918-f1289e2a830a" src="https://github.com/user-attachments/assets/b1d60271-eafa-48b9-89e8-aceb39a75c88" />
<br/>

Example KA:
```
eyJhbGciOiJFUzM4NCIsImtpZCI6Ik1CNHdGcVFVTUJJeEVEQU9CZ05WQkFNTUIxSlBUMVFnUTBFQ0JHamVSV1E9IiwieDV0I28iOnsiZGlnQWxnIjoiUzUxMiIsImRpZ1ZhbCI6InFFQ0NYYVNFOHEyTngtY180YVp4Rml2dC1aWk8yelpNelRPTklJWkY4ZTdPZzNLWFZhRjRUdnN3S2s2MFVhNXVELTQ3V3EtY2t1cmpBOFN4Q05IWllBIn0sIng1YyI6WyJNSUlCVURDQjJLQURBZ0VDQWdSbzNrVmtNQW9HQ0NxR1NNNDlCQU1ETUJJeEVEQU9CZ05WQkFNTUIxSlBUMVFnUTBFd0lCY05NalV4TURBeU1Ea3lOekF3V2hnUE1qRXlOVEV3TURJd09USTNNREJhTUJFeER6QU5CZ05WQkFNTUJsTkpSMDVGVWpCMk1CQUdCeXFHU000OUFnRUdCU3VCQkFBaUEySUFCQktBODRvOHRwb3dPYTM4VzZRdzJDNHZiTkxtQmpiWHAxbC9pVVgzeXZybWllOWFyNnoxSVRXNk85cmEwL3daK1Z4enR6ZUd2NE5lc3lRVGxaR0RyTHh6OFlFSlhlWmlJUndMQTZVOVZGcmlTaFRuZjdlS3p1dVdDRm9DOFM2eElqQUtCZ2dxaGtqT1BRUURBd05uQURCa0FqQVJISVV1TzZ4bWdQNVFTcTB4UUQxczFwNWxUNGhBU1lzbmd1YjJ4NjRUaEMvS09WU0NKWDViRUUyU24ycDViR3NDTUhpaFRGS3hGQVgyazdvRTFLakNFLytOUG1jSEtwcVh5T2J5V2FtT0hVdGZhcklVdEpTRHdCZXlTTDhFc1RJWFpBPT0iXSwidHlwIjoia2V5LWF0dGVzdGF0aW9uK2p3dCIsImlhdCI6MTc3NzkwNDEyNn0.ewogICAgImlhdCI6IDE3Nzc5MDQxMjUsCiAgICAiZXhwIjogMTc4MDU4MjUyNSwKICAgICJhdHRlc3RlZF9rZXlzIjogWwogICAgICAgIHsKICAgICAgICAgICAgImUiOiAiQVFBQiIsCiAgICAgICAgICAgICJrdHkiOiAiUlNBIiwKICAgICAgICAgICAgIm4iOiAieDJqeEZtbklhRXV5akJGWjlZRS14UnNLb09sNXZfeHAtS1V1X3g3N09YRFhoTUdQMVN4QWJVdXo0X19fV1Fyemo2Z3VRMzhxbkQ4TklOMDZNd3J0WFAtbHREaEVvNUhyb3ZPQXJlYkFiRHVWU1NTRGNiUFFaUVZIV2hXREtnVmE2UGwzZnFLVHl4VG1rWm5JNEt6Ums5MjRuYTVnYzNWdDlob0g2Z2ptV2FTOHBlTHVQdzJWTEZybm95NEJoUXdhOEI3cjFobG1TQXI1LUFDcGZQdHpSdmFjYTdMem0zSFQ3NkVINjhTX2JyQTJXSVI1MlB3a3lGX3VTZUpJQVJwYWkwaU5VTFNkUGZiWE4tTXR2SWR6ZXp4OGlLd1IzN1NtMXdCblUwTlltOG8tdE91b05sUnd3NlJYeVl4cm1OZ1J6dmxsN3hxOFFKZHZxQVRnQkZYY09RIgogICAgICAgIH0KICAgIF0sCiAgICAia2V5X3N0b3JhZ2UiOiBbCiAgICAgICAgImlzb18xODA0NV9oaWdoIgogICAgXSwKICAgICJ1c2VyX2F1dGhlbnRpY2F0aW9uIjogWwogICAgICAgICJpc29fMTgwNDVfaGlnaCIKICAgIF0sCiAgICAiY2VydGlmaWNhdGlvbiI6ICJodHRwczovL2VjLmV1cm9wYS5ldS9kaWdpdGFsLWJ1aWxkaW5nLWJsb2Nrcy9zaXRlcy9zcGFjZXMvRVVESUdJVEFMSURFTlRJVFlXQUxMRVQvcGFnZXMvNjk0NDg3NzM4L0VVK0RpZ2l0YWwrSWRlbnRpdHkrV2FsbGV0K0hvbWUiLAogICAgIm5vbmNlIjogInN0cmluZyIsCiAgICAia2V5X3N0b3JhZ2Vfc3RhdHVzIjogewogICAgICAgICJzdGF0dXMiOiB7CiAgICAgICAgICAgICJzdGF0dXNfbGlzdCI6IHsKICAgICAgICAgICAgICAgICJpZHgiOiAzOTcxLAogICAgICAgICAgICAgICAgInVyaSI6ICJodHRwczovL2lzc3Vlci5ldWRpdy5kZXYvdG9rZW5fc3RhdHVzX2xpc3QvRkMva2V5LWF0dGVzdGF0aW9uK2p3dC9iYWIxNzZmZS00ZDE2LTRmOWUtYTcyZC1mNTA2NmMzMDdmZTgiCiAgICAgICAgICAgIH0KICAgICAgICB9LAogICAgICAgICJleHAiOiAxNzgwNTgyNTI1CiAgICB9Cn0.3Mb0n5FHLCgBvFmHyaDy0GD-7oGWQIzLFrVOL3jGGDf2yarG7gqZdErfCWVbVakqlo3hfWN9-jkVC3JAP7ZINIo3Xzlpm2yd83C9I6EpA84SF0Nv6lckNQQcvIg1r5vK
```

```json
{
  "alg": "ES384",
  "kid": "MB4wFqQUMBIxEDAOBgNVBAMMB1JPT1QgQ0ECBGjeRWQ=",
  "x5t#o": {
    "digAlg": "S512",
    "digVal": "qECCXaSE8q2Nx-c_4aZxFivt-ZZO2zZMzTONIIZF8e7Og3KXVaF4TvswKk60Ua5uD-47Wq-ckurjA8SxCNHZYA"
  },
  "x5c": [
    "MIIBUDCB2KADAgECAgRo3kVkMAoGCCqGSM49BAMDMBIxEDAOBgNVBAMMB1JPT1QgQ0EwIBcNMjUxMDAyMDkyNzAwWhgPMjEyNTEwMDIwOTI3MDBaMBExDzANBgNVBAMMBlNJR05FUjB2MBAGByqGSM49AgEGBSuBBAAiA2IABBKA84o8tpowOa38W6Qw2C4vbNLmBjbXp1l/iUX3yvrmie9ar6z1ITW6O9ra0/wZ+VxztzeGv4NesyQTlZGDrLxz8YEJXeZiIRwLA6U9VFriShTnf7eKzuuWCFoC8S6xIjAKBggqhkjOPQQDAwNnADBkAjARHIUuO6xmgP5QSq0xQD1s1p5lT4hASYsngub2x64ThC/KOVSCJX5bEE2Sn2p5bGsCMHihTFKxFAX2k7oE1KjCE/+NPmcHKpqXyObyWamOHUtfarIUtJSDwBeySL8EsTIXZA=="
  ],
  "typ": "key-attestation+jwt",
  "iat": 1777904126
}
.
{
  "iat": 1777904125,
  "exp": 1780582525,
  "attested_keys": [
    {
      "e": "AQAB",
      "kty": "RSA",
      "n": "x2jxFmnIaEuyjBFZ9YE-xRsKoOl5v_xp-KUu_x77OXDXhMGP1SxAbUuz4___WQrzj6guQ38qnD8NIN06MwrtXP-ltDhEo5HrovOArebAbDuVSSSDcbPQZQVHWhWDKgVa6Pl3fqKTyxTmkZnI4KzRk924na5gc3Vt9hoH6gjmWaS8peLuPw2VLFrnoy4BhQwa8B7r1hlmSAr5-ACpfPtzRvaca7Lzm3HT76EH68S_brA2WIR52PwkyF_uSeJIARpai0iNULSdPfbXN-MtvIdzezx8iKwR37Sm1wBnU0NYm8o-tOuoNlRww6RXyYxrmNgRzvll7xq8QJdvqATgBFXcOQ"
    }
  ],
  "key_storage": [
    "iso_18045_high"
  ],
  "user_authentication": [
    "iso_18045_high"
  ],
  "certification": "https://ec.europa.eu/digital-building-blocks/sites/spaces/EUDIGITALIDENTITYWALLET/pages/694487738/EU+Digital+Identity+Wallet+Home",
  "nonce": "string",
  "key_storage_status": {
    "status": {
      "status_list": {
        "idx": 3971,
        "uri": "https://issuer.eudiw.dev/token_status_list/FC/key-attestation+jwt/bab176fe-4d16-4f9e-a72d-f5066c307fe8"
      }
    },
    "exp": 1780582525
  }
}
```

Closes #53