### PR TITLE
Make signer/key checks stricter

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -590,7 +590,9 @@
           "invalid_platform_key_attestation",
           "unsupported_platform_attested_key",
           "no_platform_attested_keys",
-          "non_unique_platform_attested_keys"
+          "non_unique_platform_attested_keys",
+          "unsupported_platform_attested_key_type",
+          "unsupported_platform_attested_key_curve"
         ]
       },
       "KeyAttestationErrorResponse": {

--- a/wallet-provider-service/src/main/kotlin/adapter/jose/SignumSignJwt.kt
+++ b/wallet-provider-service/src/main/kotlin/adapter/jose/SignumSignJwt.kt
@@ -26,10 +26,15 @@ inline fun <reified T : Any> SignJwt(
     signer: Signer,
     certificateChain: CertificateChain?,
     type: JwtType,
-): SignJwt<T> =
-    object : SignJwt<T> {
+): SignJwt<T> {
+    val signingAlgorithm =
+        signer.signatureAlgorithm.toJwsAlgorithm().getOrElse {
+            throw IllegalArgumentException("signer is not using a JwsAlgorithm", it)
+        }
+
+    return object : SignJwt<T> {
         override val signingAlgorithm: JwsAlgorithm
-            get() = signer.signatureAlgorithm.toJwsAlgorithm().getOrThrow()
+            get() = signingAlgorithm
 
         override suspend fun invoke(claims: T): JwsCompactTyped<T> {
             val header =
@@ -49,3 +54,4 @@ inline fun <reified T : Any> SignJwt(
             }
         }
     }
+}

--- a/wallet-provider-service/src/main/kotlin/config/KeyAttestationRoutes.kt
+++ b/wallet-provider-service/src/main/kotlin/config/KeyAttestationRoutes.kt
@@ -119,6 +119,14 @@ private fun Logger.warn(failure: KeyAttestationIssuanceFailure) {
         KeyAttestationIssuanceFailure.NonUniquePlatformAttestedKeys -> {
             warn("KeyAttestationIssuanceRequest validation failed, contains non-unique Platform Attested Keys")
         }
+
+        is KeyAttestationIssuanceFailure.UnsupportedPlatformAttestedKeyType -> {
+            warn("KeyAttestationIssuanceRequest validation failed, Platform Attested Key Type is not supported: ${failure.type.name}")
+        }
+
+        is KeyAttestationIssuanceFailure.UnsupportedPlatformAttestedKeyCurve -> {
+            warn("KeyAttestationIssuanceRequest validation failed, Platform Attested Key Curve is not supported: ${failure.curve.name}")
+        }
     }
 }
 
@@ -150,6 +158,12 @@ private enum class KeyAttestationError {
 
     @SerialName("non_unique_platform_attested_keys")
     NonUniquePlatformAttestedKeys,
+
+    @SerialName("unsupported_platform_attested_key_type")
+    UnsupportedPlatformAttestedKeyType,
+
+    @SerialName("unsupported_platform_attested_key_curve")
+    UnsupportedPlatformAttestedKeyCurve,
 }
 
 @Serializable
@@ -188,5 +202,13 @@ private fun KeyAttestationIssuanceFailure.toKeyAttestationErrorResponse(): KeyAt
 
         KeyAttestationIssuanceFailure.NonUniquePlatformAttestedKeys -> {
             nonEmptyListOf(KeyAttestationError.NonUniquePlatformAttestedKeys)
+        }
+
+        is KeyAttestationIssuanceFailure.UnsupportedPlatformAttestedKeyType -> {
+            nonEmptyListOf(KeyAttestationError.UnsupportedPlatformAttestedKeyType)
+        }
+
+        is KeyAttestationIssuanceFailure.UnsupportedPlatformAttestedKeyCurve -> {
+            nonEmptyListOf(KeyAttestationError.UnsupportedPlatformAttestedKeyCurve)
         }
     }.let { KeyAttestationErrorResponse(it) }

--- a/wallet-provider-service/src/main/kotlin/domain/Specs.kt
+++ b/wallet-provider-service/src/main/kotlin/domain/Specs.kt
@@ -15,6 +15,7 @@
  */
 package eu.europa.ec.eudi.walletprovider.domain
 
+import at.asitplus.signum.indispensable.josef.JwsAlgorithm
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
@@ -99,4 +100,10 @@ object TS3 {
     const val WALLET_SOLUTION_CERTIFICATION_INFORMATION: String = "wallet_solution_certification_information"
     const val CLIENT_STATUS: String = "client_status"
     const val KEY_STORAGE_STATUS: String = "key_storage_status"
+    val ALLOWED_SIGNATURE_ALGORITHMS: Set<JwsAlgorithm.Signature.EC> =
+        setOf(
+            JwsAlgorithm.Signature.EC.ES256,
+            JwsAlgorithm.Signature.EC.ES384,
+            JwsAlgorithm.Signature.EC.ES512,
+        )
 }

--- a/wallet-provider-service/src/main/kotlin/port/input/keyattestation/IssueKeyAttestation.kt
+++ b/wallet-provider-service/src/main/kotlin/port/input/keyattestation/IssueKeyAttestation.kt
@@ -23,15 +23,18 @@ import arrow.core.toNonEmptyListOrNull
 import arrow.fx.coroutines.parMapOrAccumulate
 import at.asitplus.signum.indispensable.AndroidKeystoreAttestation
 import at.asitplus.signum.indispensable.Attestation
+import at.asitplus.signum.indispensable.ECCurve
 import at.asitplus.signum.indispensable.IosHomebrewAttestation
 import at.asitplus.signum.indispensable.josef.JsonWebAlgorithm
 import at.asitplus.signum.indispensable.josef.JsonWebKeySet
+import at.asitplus.signum.indispensable.josef.JwkType
 import at.asitplus.signum.indispensable.josef.JwsAlgorithm
 import at.asitplus.signum.indispensable.josef.toJsonWebKey
 import eu.europa.ec.eudi.walletprovider.domain.*
 import eu.europa.ec.eudi.walletprovider.domain.keyattestation.*
 import eu.europa.ec.eudi.walletprovider.domain.time.Clock
 import eu.europa.ec.eudi.walletprovider.domain.tokenstatuslist.Status
+import eu.europa.ec.eudi.walletprovider.port.input.walletinstanceattestation.WalletInstanceAttestationIssuanceFailure
 import eu.europa.ec.eudi.walletprovider.port.output.challenge.ValidateChallenge
 import eu.europa.ec.eudi.walletprovider.port.output.jose.SignJwt
 import eu.europa.ec.eudi.walletprovider.port.output.platformkeyattestation.PlatformKeyAttestationValidationFailure
@@ -147,6 +150,14 @@ sealed interface KeyAttestationIssuanceFailure {
     data object NoPlatformAttestedKeys : KeyAttestationIssuanceFailure
 
     data object NonUniquePlatformAttestedKeys : KeyAttestationIssuanceFailure
+
+    data class UnsupportedPlatformAttestedKeyType(
+        val type: JwkType,
+    ) : KeyAttestationIssuanceFailure
+
+    data class UnsupportedPlatformAttestedKeyCurve(
+        val curve: ECCurve,
+    ) : KeyAttestationIssuanceFailure
 }
 
 @JvmInline
@@ -213,6 +224,18 @@ class IssueKeyAttestationLive(
         ensureNotNull(platformAttestedKeys) { KeyAttestationIssuanceFailure.NoPlatformAttestedKeys }
         ensure(platformAttestedKeys.distinct().size == platformAttestedKeys.size) {
             KeyAttestationIssuanceFailure.NonUniquePlatformAttestedKeys
+        }
+
+        platformAttestedKeys.forEach { platformAttestedKey ->
+            val platformAttestedKeyType = checkNotNull(platformAttestedKey.type) { "Platform Attested Key is missing `kty` claim" }
+            ensure(JwkType.EC == platformAttestedKeyType) {
+                KeyAttestationIssuanceFailure.UnsupportedPlatformAttestedKeyType(platformAttestedKeyType)
+            }
+
+            val platformAttestedKeyCurve = checkNotNull(platformAttestedKey.curve) { "Platform Attested Key is missing `crv` claim" }
+            ensure(platformAttestedKeyCurve in TS3.ALLOWED_SIGNATURE_ALGORITHMS.map { it.ecCurve }) {
+                KeyAttestationIssuanceFailure.UnsupportedPlatformAttestedKeyCurve(platformAttestedKeyCurve)
+            }
         }
 
         val issuedAt = clock.now()

--- a/wallet-provider-service/src/main/kotlin/port/input/keyattestation/IssueKeyAttestation.kt
+++ b/wallet-provider-service/src/main/kotlin/port/input/keyattestation/IssueKeyAttestation.kt
@@ -190,6 +190,13 @@ class IssueKeyAttestationLive(
     private val signJwt: SignJwt<KeyAttestationClaims>,
     private val preferredKeyStorageStatusPeriod: PositiveDuration,
 ) : IssueKeyAttestation {
+    init {
+        require(signJwt.signingAlgorithm in TS3.ALLOWED_SIGNATURE_ALGORITHMS) {
+            "Key Attestations must be signed using one of the following JWS Algorithms: " +
+                TS3.ALLOWED_SIGNATURE_ALGORITHMS.joinToString { it.identifier }
+        }
+    }
+
     context(_: Raise<KeyAttestationIssuanceFailure>)
     override suspend fun invoke(request: KeyAttestationIssuanceRequest): KeyAttestation {
         val supportedSigningAlgorithm = signJwt.signingAlgorithm

--- a/wallet-provider-service/src/main/kotlin/port/input/walletinstanceattestation/IssueWalletInstanceAttestation.kt
+++ b/wallet-provider-service/src/main/kotlin/port/input/walletinstanceattestation/IssueWalletInstanceAttestation.kt
@@ -216,7 +216,7 @@ class IssueWalletInstanceAttestationLive(
         }
 
         val platformAttestedKeyCurve = checkNotNull(platformAttestedKey.curve) { "Platform Attested Key is missing `crv` claim" }
-        ensure(platformAttestedKeyCurve in setOf(ECCurve.SECP_256_R_1, ECCurve.SECP_384_R_1, ECCurve.SECP_521_R_1)) {
+        ensure(platformAttestedKeyCurve in TS3.ALLOWED_SIGNATURE_ALGORITHMS.map { it.ecCurve }) {
             WalletInstanceAttestationIssuanceFailure.UnsupportedPlatformAttestedKeyCurve(platformAttestedKeyCurve)
         }
 

--- a/wallet-provider-service/src/main/kotlin/port/input/walletinstanceattestation/IssueWalletInstanceAttestation.kt
+++ b/wallet-provider-service/src/main/kotlin/port/input/walletinstanceattestation/IssueWalletInstanceAttestation.kt
@@ -178,6 +178,13 @@ class IssueWalletInstanceAttestationLive(
     private val allocateStatusListToken: AllocateStatusListToken,
     private val signJwt: SignJwt<WalletInstanceAttestationClaims>,
 ) : IssueWalletInstanceAttestation {
+    init {
+        require(signJwt.signingAlgorithm in TS3.ALLOWED_SIGNATURE_ALGORITHMS) {
+            "Wallet Instance Attestations must be signed using one of the following JWS Algorithms: " +
+                TS3.ALLOWED_SIGNATURE_ALGORITHMS.joinToString { it.identifier }
+        }
+    }
+
     context(_: Raise<WalletInstanceAttestationIssuanceFailure>)
     override suspend fun invoke(request: WalletInstanceAttestationIssuanceRequest): WalletInstanceAttestation {
         val supportedSigningAlgorithm = signJwt.signingAlgorithm


### PR DESCRIPTION
1. Do not allow instantiation of `SignJwt` with a `Signer` that doesn't use a valid `JwsAlgorithm`.
2. Do not allow instantiation of `IssueKeyAttestationLive` with a `SignJwt` that doesn't use a TS3 `JwsAlgorithm`
3. Do not allow instantiation of `IssueWalletInstanceAttestationLive` with a `SignJwt` that doesn't use a TS3 `JwsAlgorithm`
4. Check that all platform attested keys can be used with the TS3 `JwsAlgorithms`.