### PR TITLE
Refine models. Use EC keys everywhere.

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -510,7 +510,6 @@
           "invalid_challenge",
           "invalid_platform_key_attestation",
           "unsupported_platform_attested_key",
-          "unsupported_platform_attested_key_type",
           "unsupported_platform_attested_key_curve"
         ]
       },
@@ -589,9 +588,7 @@
           "invalid_challenge",
           "invalid_platform_key_attestation",
           "unsupported_platform_attested_key",
-          "no_platform_attested_keys",
           "non_unique_platform_attested_keys",
-          "unsupported_platform_attested_key_type",
           "unsupported_platform_attested_key_curve"
         ]
       },

--- a/wallet-provider-service/src/main/kotlin/adapter/platformkeyattestation/MakotoValidatePlatformKeyAttestation.kt
+++ b/wallet-provider-service/src/main/kotlin/adapter/platformkeyattestation/MakotoValidatePlatformKeyAttestation.kt
@@ -16,9 +16,11 @@
 package eu.europa.ec.eudi.walletprovider.adapter.platformkeyattestation
 
 import arrow.core.raise.context.Raise
+import arrow.core.raise.context.ensure
 import arrow.core.raise.context.raise
 import at.asitplus.attestation.AttestationResult
 import at.asitplus.signum.indispensable.Attestation
+import at.asitplus.signum.indispensable.CryptoPublicKey
 import at.asitplus.signum.indispensable.toCryptoPublicKey
 import eu.europa.ec.eudi.walletprovider.domain.platformkeyattestation.PlatformAttestedKey
 import eu.europa.ec.eudi.walletprovider.domain.toNonBlankString
@@ -60,6 +62,12 @@ class MakotoValidatePlatformKeyAttestation(
                         ),
                     )
                 }
+        ensure(cryptoPublicKey is CryptoPublicKey.EC) {
+            PlatformKeyAttestationValidationFailure.UnsupportedPlatformAttestedKey(
+                "Attested PublicKey is not an EC key".toNonBlankString(),
+                null,
+            )
+        }
 
         return PlatformAttestedKey(cryptoPublicKey, verificationResult.details)
     }

--- a/wallet-provider-service/src/main/kotlin/adapter/serialization/Serializers.kt
+++ b/wallet-provider-service/src/main/kotlin/adapter/serialization/Serializers.kt
@@ -15,6 +15,9 @@
  */
 package eu.europa.ec.eudi.walletprovider.adapter.serialization
 
+import at.asitplus.signum.indispensable.CryptoPublicKey
+import at.asitplus.signum.indispensable.josef.JsonWebKey
+import at.asitplus.signum.indispensable.josef.toJsonWebKey
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -63,4 +66,23 @@ object DurationSecondsSerializer : KSerializer<Duration> {
     }
 
     override fun deserialize(decoder: Decoder): Duration = decoder.decodeLong().seconds
+}
+
+object ECCryptoPublicKeyJsonWebKeySerializer : KSerializer<CryptoPublicKey.EC> {
+    private val serializer = JsonWebKey.serializer()
+
+    override val descriptor: SerialDescriptor = SerialDescriptor("ECCryptoPublicKeyJsonWebKey", serializer.descriptor)
+
+    override fun serialize(
+        encoder: Encoder,
+        value: CryptoPublicKey.EC,
+    ) {
+        encoder.encodeSerializableValue(serializer, value.toJsonWebKey())
+    }
+
+    override fun deserialize(decoder: Decoder): CryptoPublicKey.EC =
+        decoder
+            .decodeSerializableValue(serializer)
+            .toCryptoPublicKey()
+            .getOrThrow() as CryptoPublicKey.EC
 }

--- a/wallet-provider-service/src/main/kotlin/config/KeyAttestationRoutes.kt
+++ b/wallet-provider-service/src/main/kotlin/config/KeyAttestationRoutes.kt
@@ -112,16 +112,8 @@ private fun Logger.warn(failure: KeyAttestationIssuanceFailure) {
             }
         }
 
-        KeyAttestationIssuanceFailure.NoPlatformAttestedKeys -> {
-            warn("KeyAttestationIssuanceRequest validation failed, contains no Platform Attested Keys")
-        }
-
         KeyAttestationIssuanceFailure.NonUniquePlatformAttestedKeys -> {
             warn("KeyAttestationIssuanceRequest validation failed, contains non-unique Platform Attested Keys")
-        }
-
-        is KeyAttestationIssuanceFailure.UnsupportedPlatformAttestedKeyType -> {
-            warn("KeyAttestationIssuanceRequest validation failed, Platform Attested Key Type is not supported: ${failure.type.name}")
         }
 
         is KeyAttestationIssuanceFailure.UnsupportedPlatformAttestedKeyCurve -> {
@@ -153,14 +145,8 @@ private enum class KeyAttestationError {
     @SerialName("unsupported_platform_attested_key")
     UnsupportedPlatformAttestedKey,
 
-    @SerialName("no_platform_attested_keys")
-    NoPlatformAttestedKeys,
-
     @SerialName("non_unique_platform_attested_keys")
     NonUniquePlatformAttestedKeys,
-
-    @SerialName("unsupported_platform_attested_key_type")
-    UnsupportedPlatformAttestedKeyType,
 
     @SerialName("unsupported_platform_attested_key_curve")
     UnsupportedPlatformAttestedKeyCurve,
@@ -196,16 +182,8 @@ private fun KeyAttestationIssuanceFailure.toKeyAttestationErrorResponse(): KeyAt
                 }.distinct()
         }
 
-        KeyAttestationIssuanceFailure.NoPlatformAttestedKeys -> {
-            nonEmptyListOf(KeyAttestationError.NoPlatformAttestedKeys)
-        }
-
         KeyAttestationIssuanceFailure.NonUniquePlatformAttestedKeys -> {
             nonEmptyListOf(KeyAttestationError.NonUniquePlatformAttestedKeys)
-        }
-
-        is KeyAttestationIssuanceFailure.UnsupportedPlatformAttestedKeyType -> {
-            nonEmptyListOf(KeyAttestationError.UnsupportedPlatformAttestedKeyType)
         }
 
         is KeyAttestationIssuanceFailure.UnsupportedPlatformAttestedKeyCurve -> {

--- a/wallet-provider-service/src/main/kotlin/config/WalletInstanceAttestationRoutes.kt
+++ b/wallet-provider-service/src/main/kotlin/config/WalletInstanceAttestationRoutes.kt
@@ -106,12 +106,6 @@ private fun Logger.warn(failure: WalletInstanceAttestationIssuanceFailure) {
                 }
             }
 
-            is WalletInstanceAttestationIssuanceFailure.UnsupportedPlatformAttestedKeyType -> {
-                "WalletInstanceAttestationIssuanceRequest validation failed, " +
-                    "Platform Attested Key Type is not supported: ${failure.type.name}" to
-                    null
-            }
-
             is WalletInstanceAttestationIssuanceFailure.UnsupportedPlatformAttestedKeyCurve -> {
                 "WalletInstanceAttestationIssuanceRequest validation failed, " +
                     "Platform Attested Key Curve is not supported: ${failure.curve.name}" to
@@ -146,9 +140,6 @@ private enum class WalletInstanceAttestationError {
     @SerialName("unsupported_platform_attested_key")
     UnsupportedPlatformAttestedKey,
 
-    @SerialName("unsupported_platform_attested_key_type")
-    UnsupportedPlatformAttestedKeyType,
-
     @SerialName("unsupported_platform_attested_key_curve")
     UnsupportedPlatformAttestedKeyCurve,
 }
@@ -178,10 +169,6 @@ private fun WalletInstanceAttestationIssuanceFailure.toWalletInstanceAttestation
                     WalletInstanceAttestationError.UnsupportedPlatformAttestedKey
                 }
             }
-        }
-
-        is WalletInstanceAttestationIssuanceFailure.UnsupportedPlatformAttestedKeyType -> {
-            WalletInstanceAttestationError.UnsupportedPlatformAttestedKeyType
         }
 
         is WalletInstanceAttestationIssuanceFailure.UnsupportedPlatformAttestedKeyCurve -> {

--- a/wallet-provider-service/src/main/kotlin/domain/Specs.kt
+++ b/wallet-provider-service/src/main/kotlin/domain/Specs.kt
@@ -39,6 +39,7 @@ object RFC7519 {
 
 object RFC7800 {
     const val CONFIRMATION: String = "cnf"
+    const val JWK = "jwk"
 }
 
 object ARF {
@@ -106,4 +107,11 @@ object TS3 {
             JwsAlgorithm.Signature.EC.ES384,
             JwsAlgorithm.Signature.EC.ES512,
         )
+}
+
+/**
+ * [JSON Web Key (JWK)](https://www.rfc-editor.org/info/rfc7517/)
+ */
+object RFC7517 {
+    const val KEYS: String = "keys"
 }

--- a/wallet-provider-service/src/main/kotlin/domain/Types.kt
+++ b/wallet-provider-service/src/main/kotlin/domain/Types.kt
@@ -15,11 +15,16 @@
  */
 package eu.europa.ec.eudi.walletprovider.domain
 
+import arrow.core.NonEmptyList
+import arrow.core.serialization.NonEmptyListSerializer
+import at.asitplus.signum.indispensable.CryptoPublicKey
 import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
 import at.asitplus.signum.indispensable.io.InstantLongSerializer
 import eu.europa.ec.eudi.walletprovider.adapter.serialization.DurationSecondsSerializer
+import eu.europa.ec.eudi.walletprovider.adapter.serialization.ECCryptoPublicKeyJsonWebKeySerializer
 import eu.europa.ec.eudi.walletprovider.adapter.serialization.UriStringSerializer
 import eu.europa.ec.eudi.walletprovider.adapter.serialization.UrlStringSerializer
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 import java.net.URI
@@ -93,3 +98,19 @@ value class PositiveDuration(
 }
 
 typealias CertificationInformation = JsonElement
+
+typealias JsonWebKeyECCryptoPublicKey =
+    @Serializable(with = ECCryptoPublicKeyJsonWebKeySerializer::class)
+    CryptoPublicKey.EC
+
+@Serializable
+data class JsonWebKeySet(
+    @SerialName(RFC7517.KEYS)
+    @Serializable(with = NonEmptyListSerializer::class)
+    val keys: NonEmptyList<JsonWebKeyECCryptoPublicKey>,
+)
+
+@Serializable
+data class Confirmation(
+    @SerialName(RFC7800.JWK) val jwk: JsonWebKeyECCryptoPublicKey,
+)

--- a/wallet-provider-service/src/main/kotlin/domain/Types.kt
+++ b/wallet-provider-service/src/main/kotlin/domain/Types.kt
@@ -24,6 +24,7 @@ import eu.europa.ec.eudi.walletprovider.adapter.serialization.DurationSecondsSer
 import eu.europa.ec.eudi.walletprovider.adapter.serialization.ECCryptoPublicKeyJsonWebKeySerializer
 import eu.europa.ec.eudi.walletprovider.adapter.serialization.UriStringSerializer
 import eu.europa.ec.eudi.walletprovider.adapter.serialization.UrlStringSerializer
+import kotlinx.serialization.Required
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
@@ -105,6 +106,7 @@ typealias JsonWebKeyECCryptoPublicKey =
 
 @Serializable
 data class JsonWebKeySet(
+    @Required
     @SerialName(RFC7517.KEYS)
     @Serializable(with = NonEmptyListSerializer::class)
     val keys: NonEmptyList<JsonWebKeyECCryptoPublicKey>,
@@ -112,5 +114,5 @@ data class JsonWebKeySet(
 
 @Serializable
 data class Confirmation(
-    @SerialName(RFC7800.JWK) val jwk: JsonWebKeyECCryptoPublicKey,
+    @Required @SerialName(RFC7800.JWK) val jwk: JsonWebKeyECCryptoPublicKey,
 )

--- a/wallet-provider-service/src/main/kotlin/domain/keyattestation/KeyAttestationClaims.kt
+++ b/wallet-provider-service/src/main/kotlin/domain/keyattestation/KeyAttestationClaims.kt
@@ -17,7 +17,6 @@ package eu.europa.ec.eudi.walletprovider.domain.keyattestation
 
 import arrow.core.NonEmptyList
 import arrow.core.serialization.NonEmptyListSerializer
-import at.asitplus.signum.indispensable.josef.JsonWebKey
 import at.asitplus.signum.indispensable.josef.JwsCompactTyped
 import eu.europa.ec.eudi.walletprovider.domain.*
 import eu.europa.ec.eudi.walletprovider.domain.tokenstatuslist.Status
@@ -30,7 +29,7 @@ data class KeyAttestationClaims(
     @Required @SerialName(RFC7519.ISSUED_AT) val issuedAt: EpochSecondsInstant,
     @Required @SerialName(RFC7519.EXPIRES_AT) val expiresAt: EpochSecondsInstant,
     @Required @Serializable(with = NonEmptyListSerializer::class) @SerialName(OpenId4VCISpec.ATTESTED_KEYS)
-    val attestedKeys: NonEmptyList<JsonWebKey>,
+    val attestedKeys: NonEmptyList<JsonWebKeyECCryptoPublicKey>,
     @Required @Serializable(with = NonEmptyListSerializer::class) @SerialName(OpenId4VCISpec.KEY_STORAGE)
     val keyStorage: NonEmptyList<AttackPotentialResistance>,
     @Required @Serializable(with = NonEmptyListSerializer::class) @SerialName(OpenId4VCISpec.USER_AUTHENTICATION)

--- a/wallet-provider-service/src/main/kotlin/domain/platformkeyattestation/PlatformAttestedKey.kt
+++ b/wallet-provider-service/src/main/kotlin/domain/platformkeyattestation/PlatformAttestedKey.kt
@@ -19,7 +19,7 @@ import at.asitplus.attestation.AttestationResult
 import at.asitplus.signum.indispensable.CryptoPublicKey
 
 data class PlatformAttestedKey(
-    val publicKey: CryptoPublicKey,
+    val publicKey: CryptoPublicKey.EC,
     val attestationResult: AttestationResult,
 ) {
     init {

--- a/wallet-provider-service/src/main/kotlin/domain/walletinstanceattestation/WalletInstanceAttestationClaims.kt
+++ b/wallet-provider-service/src/main/kotlin/domain/walletinstanceattestation/WalletInstanceAttestationClaims.kt
@@ -15,7 +15,6 @@
  */
 package eu.europa.ec.eudi.walletprovider.domain.walletinstanceattestation
 
-import at.asitplus.signum.indispensable.josef.ConfirmationClaim
 import at.asitplus.signum.indispensable.josef.JwsCompactTyped
 import eu.europa.ec.eudi.walletprovider.domain.*
 import eu.europa.ec.eudi.walletprovider.domain.tokenstatuslist.Status
@@ -29,7 +28,7 @@ data class WalletInstanceAttestationClaims(
     @Required @SerialName(RFC7519.ISSUER) val issuer: Issuer,
     @Required @SerialName(RFC7519.SUBJECT) val subject: ClientId,
     @Required @SerialName(RFC7519.EXPIRES_AT) val expiresAt: EpochSecondsInstant,
-    @Required @SerialName(RFC7800.CONFIRMATION) val confirmation: ConfirmationClaim,
+    @Required @SerialName(RFC7800.CONFIRMATION) val confirmation: Confirmation,
     @SerialName(RFC7519.ISSUED_AT) val issuedAt: EpochSecondsInstant? = null,
     @SerialName(RFC7519.NOT_BEFORE) val notBefore: EpochSecondsInstant? = null,
     @Required @SerialName(OpenId4VCISpec.WALLET_NAME) val walletName: WalletName,

--- a/wallet-provider-service/src/main/kotlin/port/input/keyattestation/IssueKeyAttestation.kt
+++ b/wallet-provider-service/src/main/kotlin/port/input/keyattestation/IssueKeyAttestation.kt
@@ -19,22 +19,18 @@ import arrow.core.NonEmptyList
 import arrow.core.nonEmptyListOf
 import arrow.core.raise.context.*
 import arrow.core.serialization.NonEmptyListSerializer
-import arrow.core.toNonEmptyListOrNull
+import arrow.core.toNonEmptyListOrThrow
 import arrow.fx.coroutines.parMapOrAccumulate
 import at.asitplus.signum.indispensable.AndroidKeystoreAttestation
 import at.asitplus.signum.indispensable.Attestation
 import at.asitplus.signum.indispensable.ECCurve
 import at.asitplus.signum.indispensable.IosHomebrewAttestation
 import at.asitplus.signum.indispensable.josef.JsonWebAlgorithm
-import at.asitplus.signum.indispensable.josef.JsonWebKeySet
-import at.asitplus.signum.indispensable.josef.JwkType
 import at.asitplus.signum.indispensable.josef.JwsAlgorithm
-import at.asitplus.signum.indispensable.josef.toJsonWebKey
 import eu.europa.ec.eudi.walletprovider.domain.*
 import eu.europa.ec.eudi.walletprovider.domain.keyattestation.*
 import eu.europa.ec.eudi.walletprovider.domain.time.Clock
 import eu.europa.ec.eudi.walletprovider.domain.tokenstatuslist.Status
-import eu.europa.ec.eudi.walletprovider.port.input.walletinstanceattestation.WalletInstanceAttestationIssuanceFailure
 import eu.europa.ec.eudi.walletprovider.port.output.challenge.ValidateChallenge
 import eu.europa.ec.eudi.walletprovider.port.output.jose.SignJwt
 import eu.europa.ec.eudi.walletprovider.port.output.platformkeyattestation.PlatformKeyAttestationValidationFailure
@@ -125,11 +121,7 @@ sealed interface KeyAttestationIssuanceRequest {
         val jwkSet: JsonWebKeySet,
         @Serializable(with = NonEmptyListSerializer::class) override val supportedSigningAlgorithms: NonEmptyList<JsonWebAlgorithm>? = null,
         override val preferredKeyStorageStatusPeriod: SecondsDuration? = null,
-    ) : KeyAttestationIssuanceRequest {
-        init {
-            require(jwkSet.keys.isNotEmpty()) { "jwkSet must not be empty" }
-        }
-    }
+    ) : KeyAttestationIssuanceRequest
 }
 
 sealed interface KeyAttestationIssuanceFailure {
@@ -147,13 +139,7 @@ sealed interface KeyAttestationIssuanceFailure {
         val errors: NonEmptyList<PlatformKeyAttestationValidationFailure>,
     ) : KeyAttestationIssuanceFailure
 
-    data object NoPlatformAttestedKeys : KeyAttestationIssuanceFailure
-
     data object NonUniquePlatformAttestedKeys : KeyAttestationIssuanceFailure
-
-    data class UnsupportedPlatformAttestedKeyType(
-        val type: JwkType,
-    ) : KeyAttestationIssuanceFailure
 
     data class UnsupportedPlatformAttestedKeyCurve(
         val curve: ECCurve,
@@ -218,28 +204,21 @@ class IssueKeyAttestationLive(
                         request.platformKeyAttestations
                             .parMapOrAccumulate(Dispatchers.Default, 4) { validatePlatformKeyAttestation(it, request.challenge) }
                             .bind()
-                            .map { it.publicKey.toJsonWebKey() }
-                            .toNonEmptyListOrNull()
+                            .map { it.publicKey }
+                            .toNonEmptyListOrThrow()
                     }
                 }
 
                 is KeyAttestationIssuanceRequest.JwkSet -> {
-                    request.jwkSet.keys.toNonEmptyListOrNull()
+                    request.jwkSet.keys
                 }
             }
-
-        ensureNotNull(platformAttestedKeys) { KeyAttestationIssuanceFailure.NoPlatformAttestedKeys }
         ensure(platformAttestedKeys.distinct().size == platformAttestedKeys.size) {
             KeyAttestationIssuanceFailure.NonUniquePlatformAttestedKeys
         }
 
         platformAttestedKeys.forEach { platformAttestedKey ->
-            val platformAttestedKeyType = checkNotNull(platformAttestedKey.type) { "Platform Attested Key is missing `kty` claim" }
-            ensure(JwkType.EC == platformAttestedKeyType) {
-                KeyAttestationIssuanceFailure.UnsupportedPlatformAttestedKeyType(platformAttestedKeyType)
-            }
-
-            val platformAttestedKeyCurve = checkNotNull(platformAttestedKey.curve) { "Platform Attested Key is missing `crv` claim" }
+            val platformAttestedKeyCurve = platformAttestedKey.curve
             ensure(platformAttestedKeyCurve in TS3.ALLOWED_SIGNATURE_ALGORITHMS.map { it.ecCurve }) {
                 KeyAttestationIssuanceFailure.UnsupportedPlatformAttestedKeyCurve(platformAttestedKeyCurve)
             }

--- a/wallet-provider-service/src/main/kotlin/port/input/walletinstanceattestation/IssueWalletInstanceAttestation.kt
+++ b/wallet-provider-service/src/main/kotlin/port/input/walletinstanceattestation/IssueWalletInstanceAttestation.kt
@@ -114,7 +114,7 @@ sealed interface WalletInstanceAttestationIssuanceRequest {
 
     @Serializable
     data class Jwk(
-        val jwk: JsonWebKey,
+        val jwk: JsonWebKeyECCryptoPublicKey,
         @Serializable(with = NonEmptyListSerializer::class) override val supportedSigningAlgorithms: NonEmptyList<JsonWebAlgorithm>? = null,
         override val walletMetadata: WalletMetadata? = null,
         override val preferredClientStatusPeriod: SecondsDuration? = null,
@@ -134,10 +134,6 @@ sealed interface WalletInstanceAttestationIssuanceFailure {
 
     class InvalidPlatformKeyAttestation(
         val error: PlatformKeyAttestationValidationFailure,
-    ) : WalletInstanceAttestationIssuanceFailure
-
-    data class UnsupportedPlatformAttestedKeyType(
-        val type: JwkType,
     ) : WalletInstanceAttestationIssuanceFailure
 
     data class UnsupportedPlatformAttestedKeyCurve(
@@ -206,9 +202,10 @@ class IssueWalletInstanceAttestationLive(
                     }
 
                     withError({ WalletInstanceAttestationIssuanceFailure.InvalidPlatformKeyAttestation(it) }) {
-                        validatePlatformKeyAttestation(request.platformKeyAttestation, request.challenge)
-                            .publicKey
-                            .toJsonWebKey()
+                        validatePlatformKeyAttestation(
+                            request.platformKeyAttestation,
+                            request.challenge,
+                        ).publicKey
                     }
                 }
 
@@ -217,12 +214,7 @@ class IssueWalletInstanceAttestationLive(
                 }
             }
 
-        val platformAttestedKeyType = checkNotNull(platformAttestedKey.type) { "Platform Attested Key is missing `kty` claim" }
-        ensure(JwkType.EC == platformAttestedKeyType) {
-            WalletInstanceAttestationIssuanceFailure.UnsupportedPlatformAttestedKeyType(platformAttestedKeyType)
-        }
-
-        val platformAttestedKeyCurve = checkNotNull(platformAttestedKey.curve) { "Platform Attested Key is missing `crv` claim" }
+        val platformAttestedKeyCurve = platformAttestedKey.curve
         ensure(platformAttestedKeyCurve in TS3.ALLOWED_SIGNATURE_ALGORITHMS.map { it.ecCurve }) {
             WalletInstanceAttestationIssuanceFailure.UnsupportedPlatformAttestedKeyCurve(platformAttestedKeyCurve)
         }
@@ -242,7 +234,7 @@ class IssueWalletInstanceAttestationLive(
                 issuer,
                 clientId,
                 expiresAt = expiresAt,
-                ConfirmationClaim(jsonWebKey = platformAttestedKey),
+                Confirmation(platformAttestedKey),
                 issuedAt = issuedAt,
                 notBefore = issuedAt,
                 walletName = walletName,

--- a/wallet-provider-service/src/test/kotlin/IssueKeyAttestationTest.kt
+++ b/wallet-provider-service/src/test/kotlin/IssueKeyAttestationTest.kt
@@ -15,12 +15,13 @@
  */
 package eu.europa.ec.eudi.walletprovider
 
+import arrow.core.nonEmptyListOf
+import at.asitplus.signum.indispensable.CryptoPublicKey
 import at.asitplus.signum.indispensable.ECCurve
-import at.asitplus.signum.indispensable.josef.JsonWebKeySet
 import at.asitplus.signum.indispensable.josef.JwsCompactTyped
-import at.asitplus.signum.indispensable.josef.toJsonWebKey
 import at.asitplus.signum.supreme.sign.EphemeralKey
 import eu.europa.ec.eudi.walletprovider.config.WalletProviderConfiguration
+import eu.europa.ec.eudi.walletprovider.domain.JsonWebKeySet
 import eu.europa.ec.eudi.walletprovider.domain.SecondsDuration
 import eu.europa.ec.eudi.walletprovider.domain.keyattestation.KeyAttestation
 import eu.europa.ec.eudi.walletprovider.domain.keyattestation.KeyAttestationClaims
@@ -114,12 +115,13 @@ private fun HttpClient.runKeyAttestationTestCase(
                 jwkSet =
                     JsonWebKeySet(
                         keys =
-                            listOf(
+                            nonEmptyListOf(
                                 EphemeralKey {
                                     ec {
                                         curve = ECCurve.SECP_256_R_1
                                     }
-                                }.getOrThrow().publicKey.toJsonWebKey(),
+                                }.getOrThrow()
+                                    .publicKey as CryptoPublicKey.EC,
                             ),
                     ),
                 preferredKeyStorageStatusPeriod = preferredKeyStorageStatusPeriod,

--- a/wallet-provider-service/src/test/kotlin/IssueWalletInstanceAttestationTest.kt
+++ b/wallet-provider-service/src/test/kotlin/IssueWalletInstanceAttestationTest.kt
@@ -15,9 +15,9 @@
  */
 package eu.europa.ec.eudi.walletprovider
 
+import at.asitplus.signum.indispensable.CryptoPublicKey
 import at.asitplus.signum.indispensable.ECCurve
 import at.asitplus.signum.indispensable.josef.JwsCompactTyped
-import at.asitplus.signum.indispensable.josef.toJsonWebKey
 import at.asitplus.signum.supreme.sign.EphemeralKey
 import eu.europa.ec.eudi.walletprovider.config.WalletProviderConfiguration
 import eu.europa.ec.eudi.walletprovider.domain.SecondsDuration
@@ -142,7 +142,8 @@ private fun HttpClient.runWalletInstanceAttestationTestCase(
                         ec {
                             curve = ECCurve.SECP_256_R_1
                         }
-                    }.getOrThrow().publicKey.toJsonWebKey(),
+                    }.getOrThrow()
+                        .publicKey as CryptoPublicKey.EC,
                 walletMetadata = walletMetadata,
                 preferredClientStatusPeriod = preferredClientStatusPeriod,
             )


### PR DESCRIPTION
This PR refines models, and requires EC keys throughout the application for WIA and KA issuance.