### PR TITLE
Upgrade sonarqube-scan-action to v7.2.1

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -39,7 +39,7 @@ jobs:
           cache-provider: 'basic'
       - run: ./gradlew test koverXmlReport
       - name: Analysis on push or workflow dispatch
-        uses: sonarsource/sonarqube-scan-action@v7.2.0
+        uses: sonarsource/sonarqube-scan-action@v7.2.1
         if: (github.event_name == 'push'|| github.event_name == 'workflow_dispatch')
         with:
           projectBaseDir: ${{ github.workspace }}
@@ -55,7 +55,7 @@ jobs:
             -Dsonar.java.binaries=wallet-provider-service/build/classes/kotlin/
             -Dsonar.kotlin.binaries=wallet-provider-service/build/classes/kotlin/
       - name: Analysis on pull request
-        uses: sonarsource/sonarqube-scan-action@v7.2.0
+        uses: sonarsource/sonarqube-scan-action@v7.2.1
         if: (github.event_name == 'pull_request_target')
         with:
           projectBaseDir: ${{ github.workspace }}


### PR DESCRIPTION
This PR upgrades `sonarqube-scan-action` to `v7.2.1`.

We are holding of `v8` to investigate any possible breaking changes that might have been introduced.