### PR TITLE
Make Status List Service fully configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,18 @@ Description: URL of the **take** operation of [eudi-srv-statuslist-py](https://g
 Variable: `TOKENSTATUSLISTSERVICE_APIKEY`  
 Description: API Key used to access [eudi-srv-statuslist-py](https://github.com/eu-digital-identity-wallet/eudi-srv-statuslist-py).  
 
+Variable: `TOKENSTATUSLISTSERVICE_COUNTRY`    
+Description: Country in which Status List Tokens will be allocated in.   
+Default value: `FC`    
+
+Variable: `TOKENSTATUSLISTSERVICE_WALLETINSTANCEATTESTATIONSTATUSLIST`    
+Description: Name of the Status List used for allocating Status List Tokens for issued Wallet Instance Attestations.   
+Default value: `oauth-client-attestation+jwt`   
+
+Variable: `TOKENSTATUSLISTSERVICE_KEYATTESTATIONSTATUSLIST`    
+Description: Name of the Status List used for allocating Status List Tokens for issued Key Attestations.   
+Default value: `key-attestation+jwt`  
+
 ### Swagger UI Configuration
 
 Wallet Provider exposes an OpenAPI specification of its endpoints using Swagger UI. You can configure the Swagger UI using the following environment variables:

--- a/wallet-provider-service/src/main/kotlin/adapter/tokenstatuslist/TokenStatusListServiceAllocateStatusListToken.kt
+++ b/wallet-provider-service/src/main/kotlin/adapter/tokenstatuslist/TokenStatusListServiceAllocateStatusListToken.kt
@@ -19,11 +19,8 @@ package eu.europa.ec.eudi.walletprovider.adapter.tokenstatuslist
 
 import com.eygraber.uri.Url
 import eu.europa.ec.eudi.walletprovider.domain.NonBlankString
-import eu.europa.ec.eudi.walletprovider.domain.specification.AttestationBasedClientAuthentication
-import eu.europa.ec.eudi.walletprovider.domain.specification.OpenId4VCI
 import eu.europa.ec.eudi.walletprovider.domain.time.Clock
 import eu.europa.ec.eudi.walletprovider.domain.tokenstatuslist.Status
-import eu.europa.ec.eudi.walletprovider.domain.tokenstatuslist.StatusListToken
 import eu.europa.ec.eudi.walletprovider.port.output.tokenstatuslist.AllocateStatusListToken
 import eu.europa.ec.eudi.walletprovider.port.output.tokenstatuslist.StatusList
 import io.ktor.client.*
@@ -32,30 +29,31 @@ import io.ktor.client.plugins.*
 import io.ktor.client.request.forms.*
 import io.ktor.http.*
 import java.time.format.DateTimeFormatter
-import kotlin.time.Instant
 
 typealias ApiKey = NonBlankString
+typealias CountryCode = NonBlankString
+typealias StatusListName = NonBlankString
 
-class TokenStatusListServiceAllocateStatusListToken(
-    private val httpClient: HttpClient,
-    private val serviceUrl: Url,
-    private val apiKey: ApiKey,
-    private val clock: Clock,
-) : AllocateStatusListToken {
-    override suspend fun invoke(
-        statusList: StatusList,
-        expiresAt: Instant,
-    ): StatusListToken =
+fun AllocateStatusListToken(
+    clock: Clock,
+    httpClient: HttpClient,
+    serviceUrl: Url,
+    apiKey: ApiKey,
+    country: CountryCode,
+    walletInstantAttestationStatusList: StatusListName,
+    keyAttestationStatusList: StatusListName,
+): AllocateStatusListToken =
+    AllocateStatusListToken { statusList, expiresAt ->
         httpClient
             .submitForm(
                 serviceUrl.toString(),
                 Parameters.build {
-                    append("country", "FC")
+                    append("country", country.value)
                     append(
                         "doctype",
                         when (statusList) {
-                            StatusList.WalletInstanceAttestation -> AttestationBasedClientAuthentication.CLIENT_ATTESTATION_JWT_TYPE
-                            StatusList.KeyAttestation -> OpenId4VCI.KEY_ATTESTATION_JWT_TYPE
+                            StatusList.WalletInstanceAttestation -> walletInstantAttestationStatusList.value
+                            StatusList.KeyAttestation -> keyAttestationStatusList.value
                         },
                     )
                     append(
@@ -72,4 +70,4 @@ class TokenStatusListServiceAllocateStatusListToken(
                 }
             }.body<Status>()
             .statusList
-}
+    }

--- a/wallet-provider-service/src/main/kotlin/config/WalletProviderConfiguration.kt
+++ b/wallet-provider-service/src/main/kotlin/config/WalletProviderConfiguration.kt
@@ -21,7 +21,11 @@ import com.sksamuel.hoplite.*
 import com.sksamuel.hoplite.decoder.Decoder
 import com.sksamuel.hoplite.fp.invalid
 import com.sksamuel.hoplite.fp.valid
+import eu.europa.ec.eudi.walletprovider.adapter.tokenstatuslist.CountryCode
+import eu.europa.ec.eudi.walletprovider.adapter.tokenstatuslist.StatusListName
 import eu.europa.ec.eudi.walletprovider.domain.*
+import eu.europa.ec.eudi.walletprovider.domain.specification.AttestationBasedClientAuthentication
+import eu.europa.ec.eudi.walletprovider.domain.specification.OpenId4VCI
 import eu.europa.ec.eudi.walletprovider.domain.walletinstanceattestation.WalletLink
 import eu.europa.ec.eudi.walletprovider.domain.walletinstanceattestation.WalletName
 import eu.europa.ec.eudi.walletprovider.domain.walletinstanceattestation.WalletVersion
@@ -240,6 +244,11 @@ class UrlDecoder : Decoder<Url> {
 data class TokenStatusListServiceConfiguration(
     val serviceUrl: Url,
     val apiKey: Secret,
+    val country: CountryCode = "FC".toNonBlankString(),
+    val walletInstanceAttestationStatusList: StatusListName =
+        AttestationBasedClientAuthentication.CLIENT_ATTESTATION_JWT_TYPE
+            .toNonBlankString(),
+    val keyAttestationStatusList: StatusListName = OpenId4VCI.KEY_ATTESTATION_JWT_TYPE.toNonBlankString(),
 )
 
 data class IssuerConfiguration(

--- a/wallet-provider-service/src/main/kotlin/config/WalletProviderModuleConfiguration.kt
+++ b/wallet-provider-service/src/main/kotlin/config/WalletProviderModuleConfiguration.kt
@@ -26,8 +26,8 @@ import eu.europa.ec.eudi.walletprovider.adapter.jose.SignumSignJwt
 import eu.europa.ec.eudi.walletprovider.adapter.persistence.RunInTransactionLive
 import eu.europa.ec.eudi.walletprovider.adapter.persistence.challenge.ChallengeRepositoryLive
 import eu.europa.ec.eudi.walletprovider.adapter.platformkeyattestation.MakotoValidatePlatformKeyAttestation
+import eu.europa.ec.eudi.walletprovider.adapter.tokenstatuslist.AllocateStatusListToken
 import eu.europa.ec.eudi.walletprovider.adapter.tokenstatuslist.ApiKey
-import eu.europa.ec.eudi.walletprovider.adapter.tokenstatuslist.TokenStatusListServiceAllocateStatusListToken
 import eu.europa.ec.eudi.walletprovider.config.IosKeyAttestationConfiguration.ApplicationConfiguration.IosEnvironment
 import eu.europa.ec.eudi.walletprovider.domain.JwsSigner
 import eu.europa.ec.eudi.walletprovider.domain.JwtType
@@ -97,12 +97,15 @@ fun Application.configureWalletProviderModule(
     val makotoAttestationService = createMakotoAttestationService(config, clock)
     val validatePlatformKeyAttestation = MakotoValidatePlatformKeyAttestation(makotoAttestationService)
 
-    val generateStatusListToken =
-        TokenStatusListServiceAllocateStatusListToken(
+    val allocateStatusListToken =
+        AllocateStatusListToken(
+            clock,
             httpClient,
             config.tokenStatusListService.serviceUrl,
             ApiKey(config.tokenStatusListService.apiKey.value),
-            clock,
+            country = config.tokenStatusListService.country,
+            walletInstantAttestationStatusList = config.tokenStatusListService.walletInstanceAttestationStatusList,
+            keyAttestationStatusList = config.tokenStatusListService.keyAttestationStatusList,
         )
 
     val issueWalletInstanceAttestation =
@@ -118,7 +121,7 @@ fun Application.configureWalletProviderModule(
             walletVersion = config.walletInstanceAttestation.walletVersion,
             config.walletInstanceAttestation.walletSolutionCertificationInformation,
             config.walletInstanceAttestation.clientStatusValidity,
-            generateStatusListToken,
+            allocateStatusListToken,
             SignumSignJwt(
                 signer,
                 certificateChain,
@@ -132,7 +135,7 @@ fun Application.configureWalletProviderModule(
             validateChallenge,
             validatePlatformKeyAttestation,
             config.keyAttestation.validity,
-            generateStatusListToken,
+            allocateStatusListToken,
             config.keyAttestation.certification,
             SignumSignJwt(
                 signer,


### PR DESCRIPTION
This PR introduces new env. variable to allow full customization of the Token Status List service configuration.

Newly introduced env. variables are for:
1. The Country in which Tokens are allocated
2. The name of the WIA Status List
3. The name of the KA Status List

The previously hardcoded values are now the defaults.